### PR TITLE
Use console OAuth flow by default

### DIFF
--- a/setup_gmail_oauth.py
+++ b/setup_gmail_oauth.py
@@ -75,6 +75,7 @@ def check_credentials_file():
 def setup_oauth():
     """OAuth認証を実行してトークンを取得"""
     creds = None
+    use_console = True
 
     # 既存のトークンがあれば読み込み
     if TOKEN_FILE.exists():
@@ -94,11 +95,6 @@ def setup_oauth():
             flow = InstalledAppFlow.from_client_secrets_file(
                 str(CREDENTIALS_FILE), SCOPES
             )
-            use_console = os.environ.get("OAUTH_USE_CONSOLE", "").lower() in {
-                "1",
-                "true",
-                "yes",
-            }
             if use_console:
                 print("""
 ╔══════════════════════════════════════════════════════════════════╗


### PR DESCRIPTION
### Motivation
- Prefer the console-based OAuth flow to avoid failures with localhost callback redirects when obtaining Gmail tokens.

### Description
- In `setup_gmail_oauth.py` the `setup_oauth` flow now sets `use_console = True` by default and removes the `OAUTH_USE_CONSOLE` environment variable check so the console authorization path is used by default.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985b5f8aa588325baef057e395306fa)