### PR TITLE
Support cloud-only Gmail auth (service account via env/base64) and update deploy docs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -111,6 +111,7 @@ if [ ! -f "agent/.env" ]; then
     cat > agent/.env << EOF
 # Gmail設定
 GMAIL_USER_EMAIL=security-team@your-domain.com
+GMAIL_SERVICE_ACCOUNT_JSON_BASE64=your-service-account-json-base64
 SIDFM_SENDER_EMAIL=noreply@sidfm.com
 
 # SBOM設定


### PR DESCRIPTION
### Motivation

- Enable deployments that run entirely on Google Cloud by avoiding local browser OAuth flows and supporting Workspace domain delegation via a service account provided through environment variables.

### Description

- Updated `agent/tools/gmail_tools.py` to accept service account credentials from `GMAIL_SERVICE_ACCOUNT_JSON` (JSON string) or `GMAIL_SERVICE_ACCOUNT_JSON_BASE64` (Base64-encoded JSON) and use `service_account.Credentials.from_service_account_info` for domain delegation when `GMAIL_USER_EMAIL` is set.
- Added detection and decoding logic for the Base64 env var and preserved fallback behavior to `GOOGLE_APPLICATION_CREDENTIALS` file and default credentials, with improved `auth_method` logging.
- Documented a cloud-only deployment workflow in `README.md`, added guidance for creating a service account, exporting a Base64 key, granting domain-wide delegation, and sharing resources with the service account, and added a warning that personal Gmail OAuth requires local browser interaction.
- Updated `deploy.sh` to include a placeholder `GMAIL_SERVICE_ACCOUNT_JSON_BASE64` in the `agent/.env` template so `./deploy.sh` can produce a cloud-ready env file.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985b7ecb17883259c7cd4fa72b312a5)