### PR TITLE
Set redirect_uri for Gmail OAuth console flow

### DIFF
--- a/setup_gmail_oauth.py
+++ b/setup_gmail_oauth.py
@@ -95,6 +95,7 @@ def setup_oauth():
             flow = InstalledAppFlow.from_client_secrets_file(
                 str(CREDENTIALS_FILE), SCOPES
             )
+            flow.redirect_uri = "http://localhost"
             if use_console:
                 print("""
 ╔══════════════════════════════════════════════════════════════════╗


### PR DESCRIPTION
### Motivation
- Fix the `Missing required parameter: redirect_uri (invalid_request)` error by ensuring the OAuth authorization URL includes a redirect URI when running the console authorization flow in `setup_gmail_oauth.py`.

### Description
- Add `flow.redirect_uri = "http://localhost"` immediately after creating the `InstalledAppFlow` in `setup_gmail_oauth.py` so the generated authorization URL contains a `redirect_uri` parameter.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69892c19cab88325945f54be89f54c4e)