### PR TITLE
Add BigQuery-backed SBOM/owner mapping support and migration docs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,9 +30,12 @@ steps:
         cat > agent/.env <<EOF
         GMAIL_OAUTH_TOKEN=$(gcloud secrets versions access latest --secret=vuln-agent-gmail-oauth-token 2>/dev/null || echo '')
         SIDFM_SENDER_EMAIL=$(gcloud secrets versions access latest --secret=vuln-agent-sidfm-sender 2>/dev/null || echo 'noreply@sidfm.com')
+        SBOM_DATA_BACKEND=$(gcloud secrets versions access latest --secret=vuln-agent-sbom-data-backend 2>/dev/null || echo 'sheets')
         SBOM_SPREADSHEET_ID=$(gcloud secrets versions access latest --secret=vuln-agent-sbom-spreadsheet-id 2>/dev/null || echo '')
         SBOM_SHEET_NAME=$(gcloud secrets versions access latest --secret=vuln-agent-sbom-sheet-name 2>/dev/null || echo 'SBOM')
         OWNER_SHEET_NAME=$(gcloud secrets versions access latest --secret=vuln-agent-owner-sheet-name 2>/dev/null || echo '担当者マッピング')
+        BQ_SBOM_TABLE_ID=$(gcloud secrets versions access latest --secret=vuln-agent-bq-sbom-table-id 2>/dev/null || echo '')
+        BQ_OWNER_MAPPING_TABLE_ID=$(gcloud secrets versions access latest --secret=vuln-agent-bq-owner-table-id 2>/dev/null || echo '')
         DEFAULT_CHAT_SPACE_ID=$(gcloud secrets versions access latest --secret=vuln-agent-chat-space-id 2>/dev/null || echo '')
         BQ_HISTORY_TABLE_ID=$(gcloud secrets versions access latest --secret=vuln-agent-bq-table-id 2>/dev/null || echo '')
         GCP_PROJECT_ID=${PROJECT_ID}

--- a/deploy.sh
+++ b/deploy.sh
@@ -114,9 +114,12 @@ GMAIL_USER_EMAIL=security-team@your-domain.com
 SIDFM_SENDER_EMAIL=noreply@sidfm.com
 
 # SBOM設定
+SBOM_DATA_BACKEND=sheets
 SBOM_SPREADSHEET_ID=your-spreadsheet-id
 SBOM_SHEET_NAME=SBOM
 OWNER_SHEET_NAME=担当者マッピング
+BQ_SBOM_TABLE_ID=
+BQ_OWNER_MAPPING_TABLE_ID=
 
 # Google Chat設定
 DEFAULT_CHAT_SPACE_ID=spaces/your-space-id


### PR DESCRIPTION
### Motivation
- Allow using BigQuery as the SBOM and owner-mapping backend when Sheets cannot be used (org policies / larger datasets). 
- Preserve existing behavior by default (`Sheets`) and provide an `auto` mode so environments can switch to BigQuery without breaking current deployments.

### Description
- Added selectable SBOM data backend in `agent/tools/sheets_tools.py` with `SBOM_DATA_BACKEND` (`sheets` / `bigquery` / `auto`) and implemented `_get_bigquery_client`, `_load_sbom_from_bigquery`, and `_load_owner_mapping_from_bigquery` while keeping Sheets loaders for backward compatibility. 
- Implemented BigQuery table lookups driven by `BQ_SBOM_TABLE_ID` and `BQ_OWNER_MAPPING_TABLE_ID` and maintained a 5-minute cache for performance. 
- Updated `setup_cloud.sh` to prompt/register `vuln-agent-sbom-data-backend`, create `vuln_agent.sbom_packages` and `vuln_agent.owner_mapping` tables, register `vuln-agent-bq-sbom-table-id` and `vuln-agent-bq-owner-table-id` secrets, and include new variables in the generated `agent/.env`. 
- Updated `cloudbuild.yaml` and `deploy.sh` to inject the new env vars (`SBOM_DATA_BACKEND`, `BQ_SBOM_TABLE_ID`, `BQ_OWNER_MAPPING_TABLE_ID`) and expanded `README.md` with BigQuery migration instructions, sample `bq` inserts for the provided test sheets, and secret update commands.

### Testing
- `python -m py_compile agent/tools/sheets_tools.py` — succeeded. 
- `bash -n setup_cloud.sh` — syntax check succeeded. 
- `bash -n deploy.sh` — syntax check succeeded. 
- `python -c "import yaml; yaml.safe_load(open('cloudbuild.yaml'))"` — succeeded (valid YAML). 
- Runtime check: set `SBOM_DATA_BACKEND=bigquery` and with no `BQ_*` table envs, called `search_sbom_by_purl` and `get_owner_mapping` which returned empty results and emitted expected warnings, demonstrating safe fallback behavior — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a87838a1083259855e9490e88a686)