### PR TITLE
Fix duplicate SBOM backend helpers and normalize owner mapping patterns

### DIFF
--- a/agent/tools/sheets_tools.py
+++ b/agent/tools/sheets_tools.py
@@ -60,36 +60,6 @@ def _get_bigquery_client() -> bigquery.Client:
     return bigquery.Client(project=project)
 
 
-def _get_sbom_data_backend() -> str:
-    """
-    SBOMデータ取得バックエンドを返す。
-
-    環境変数:
-      - SBOM_DATA_BACKEND: sheets | bigquery | auto (default: sheets)
-
-    auto の場合は BigQuery テーブル設定があれば bigquery、なければ sheets を利用。
-    """
-    configured = os.environ.get("SBOM_DATA_BACKEND", "sheets").strip().lower()
-    if configured not in {"sheets", "bigquery", "auto"}:
-        logger.warning("Invalid SBOM_DATA_BACKEND=%s, fallback to sheets", configured)
-        return "sheets"
-
-    if configured == "auto":
-        sbom_table_id = os.environ.get("BQ_SBOM_TABLE_ID", "").strip()
-        owner_table_id = os.environ.get("BQ_OWNER_MAPPING_TABLE_ID", "").strip()
-        if sbom_table_id and owner_table_id:
-            return "bigquery"
-        return "sheets"
-
-    return configured
-
-
-def _get_bigquery_client() -> bigquery.Client:
-    """BigQueryクライアントを構築"""
-    project = os.environ.get("GCP_PROJECT_ID") or None
-    return bigquery.Client(project=project)
-
-
 def _get_sheets_service():
     """Sheets APIサービスを構築"""
     sa_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
@@ -277,8 +247,9 @@ def _load_owner_mapping_from_sheets() -> list[dict]:
             while len(row) < 5:
                 row.append("")
 
+            normalized_pattern = row[0].strip() or "*"
             mappings.append({
-                "pattern": row[0],
+                "pattern": normalized_pattern,
                 "system_name": row[1],
                 "owner_email": row[2],
                 "owner_name": row[3],


### PR DESCRIPTION
### Motivation
- Remove duplicate helper definitions to eliminate hidden runtime divergence and future maintenance bugs in SBOM backend selection logic.
- Ensure owner mapping patterns loaded from Sheets behave as intended when cells are empty or contain only whitespace.

### Description
- Removed the duplicate definitions and consolidated SBOM backend logic into a single `_get_sbom_data_backend` and `_get_bigquery_client` implementation in `agent/tools/sheets_tools.py`.
- Normalize owner `pattern` values when loading mappings from Google Sheets by trimming whitespace and treating empty patterns as `"*"` to preserve default-owner semantics.
- Preserve existing behavior for BigQuery-loaded mappings by keeping `COALESCE(NULLIF(TRIM(pattern), ''), '*')` in the BigQuery query.
- No public API changes; behavior is internal to `agent/tools/sheets_tools.py` and owner-mapping matching.

### Testing
- Ran `python -m compileall -q agent scheduler live_gateway` which succeeded without syntax errors.
- Executed `pytest -q` which failed during test collection due to missing Google Application Default Credentials (`DefaultCredentialsError`) in the CI environment, not related to the changes.
- Performed focused manual checks calling `_version_matches_range` and basic `_load_owner_mapping_from_sheets` behavior (pattern normalization) which returned expected results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a924ecc0483259243477021614b2b)