### PR TITLE
Install google-adk into user PATH in Cloud Build deploy step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,8 @@ steps:
     args:
       - "-c"
       - |
-        pip install -q google-adk
+        python3 -m pip install -q --user google-adk
+        export PATH="${HOME}/.local/bin:${PATH}"
         cd agent
         adk deploy agent_engine \
           --project=${PROJECT_ID} \


### PR DESCRIPTION
### Motivation
- Cloud Build was failing during the `deploy-agent` step with a non-zero exit (`127`) consistent with the `adk` CLI not being found after installation. 
- The change ensures the `google-adk` installer is placed into the build user's local bin so subsequent `adk deploy` runs correctly.

### Description
- Updated `cloudbuild.yaml` `deploy-agent` step to install `google-adk` via `python3 -m pip install -q --user google-adk` instead of a system `pip` install. 
- Added `export PATH="${HOME}/.local/bin:${PATH}"` so the `adk` executable from the user install is resolvable in the same build step. 
- No other changes were made outside of `cloudbuild.yaml`.

### Testing
- Parsed `cloudbuild.yaml` successfully using `python3 -c "import yaml; yaml.safe_load(open('cloudbuild.yaml'))"` and it returned OK. 
- Verified the `git diff` shows only the install and PATH lines changed and a commit was created for the update. 
- The change targets the `gcloud builds submit` failure (exit `127`) and should allow `adk` to be invoked during the build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698abc7cb64c832586a78935ba31bdee)