### PR TITLE
Fix ADK install path in Cloud Build deploy-agent step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -54,11 +54,12 @@ steps:
       - "-c"
       - |
         echo "[Step 2/5] Agent Engine のデプロイ準備: google-adk をインストールします"
-        python3 -m pip install -q --user google-adk
-        adk_bin="$(python3 -m site --user-base)/bin/adk"
+        python3 -m venv /workspace/.venv-adk
+        /workspace/.venv-adk/bin/pip install -q google-adk
+        adk_bin="/workspace/.venv-adk/bin/adk"
         if [ ! -x "$$adk_bin" ]; then
           echo "adk CLI が見つかりません: $$adk_bin"
-          python3 -m pip show google-adk || true
+          /workspace/.venv-adk/bin/pip show google-adk || true
           exit 127
         fi
         echo "[Step 2/5] Agent Engine をデプロイします"


### PR DESCRIPTION
### Motivation
- Avoid PEP 668 and unreliable `--user` installations inside Cloud Build by creating an isolated, predictable virtual environment for the ADK CLI. 
- Ensure `adk` can be invoked deterministically from a known path inside the build container so the deploy step is stable.

### Description
- Create a dedicated venv with `python3 -m venv /workspace/.venv-adk` in the `deploy-agent` step and install `google-adk` with `/workspace/.venv-adk/bin/pip install -q google-adk`.
- Set `adk_bin` to `/workspace/.venv-adk/bin/adk` and perform the executable existence check against that exact path.
- Replace the diagnostic `pip show` call with `/workspace/.venv-adk/bin/pip show google-adk` to match the venv context.
- Preserve the existing `cd agent` and `"$adk_bin" deploy agent_engine ...` execution flow so behavior after installation is unchanged.

### Testing
- Applied the patch and updated `cloudbuild.yaml` successfully using the patch tool (`apply_patch` succeeded).
- Verified the file diff with `git diff -- cloudbuild.yaml` and inspected the modified lines with `nl -ba cloudbuild.yaml | sed -n '48,82p'`, both showing the new venv installation and `adk_bin` path.
- Committed the change (`git commit`) and confirmed the commit via `git show --stat --oneline HEAD` which reported the file change as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ac5f17bc08325b33c3fa2e1b4b3ac)