### PR TITLE
Prevent redeploys from using non-existent ReasoningEngine IDs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -85,12 +85,22 @@ steps:
 
         token="$(gcloud auth print-access-token)"
         api_base="https://${_REGION}-aiplatform.googleapis.com/v1"
+        verify_engine_exists() {
+          local engine_name="$1"
+          [ -z "$engine_name" ] && return 1
+          local status
+          status="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $$token" \
+            "$$api_base/$$engine_name")"
+          [ "$$status" = "200" ]
+        }
         engines_json="$(curl -sSf -H "Authorization: Bearer $$token" \
           "$$api_base/projects/${PROJECT_ID}/locations/${_REGION}/reasoningEngines")"
 
         latest_engine="$(printf '%s' "$$engines_json" | python3 -c 'import json,sys; display_name=sys.argv[1]; engines=json.load(sys.stdin).get("reasoningEngines", []); filtered=[e for e in engines if e.get("displayName")==display_name and e.get("name")]; filtered.sort(key=lambda e: e.get("createTime", ""), reverse=True); print(filtered[0]["name"] if filtered else "")' "${_AGENT_NAME}")"
         if [ -z "$$latest_engine" ]; then
           echo "警告: 最新の Agent Engine を特定できませんでした。"
+        elif ! verify_engine_exists "$$latest_engine"; then
+          echo "警告: 最新候補の Agent Engine が見つからないため Secret 更新をスキップします: $$latest_engine"
         else
           if ! gcloud secrets describe vuln-agent-resource-name >/dev/null 2>&1; then
             echo "vuln-agent-resource-name が存在しないため作成します。"
@@ -140,11 +150,26 @@ steps:
       - "-c"
       - |
         echo "[Step 3/5] Live Gateway デプロイ条件を確認します"
+        token="$(gcloud auth print-access-token)"
+        api_base="https://${_REGION}-aiplatform.googleapis.com/v1"
+        verify_engine_exists() {
+          local engine_name="$1"
+          [ -z "$engine_name" ] && return 1
+          local status
+          status="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $$token" \
+            "$$api_base/$$engine_name")"
+          [ "$$status" = "200" ]
+        }
         AGENT_RESOURCE_NAME=$(gcloud secrets versions access latest \
           --secret=vuln-agent-resource-name 2>/dev/null || echo '')
         if [ -z "$$AGENT_RESOURCE_NAME" ]; then
           echo "vuln-agent-resource-name が未登録です。Live Gateway のデプロイをスキップします。"
           exit 0
+        fi
+        if ! verify_engine_exists "$$AGENT_RESOURCE_NAME"; then
+          echo "vuln-agent-resource-name が不正です（ReasoningEngine が存在しません）: $$AGENT_RESOURCE_NAME"
+          echo "Live Gateway のデプロイを中止します。"
+          exit 1
         fi
         GEMINI_KEY=$(gcloud secrets versions access latest \
           --secret=vuln-agent-gemini-api-key 2>/dev/null || echo '')
@@ -176,11 +201,26 @@ steps:
       - "-c"
       - |
         echo "[Step 4/5] Scheduler デプロイ条件を確認します"
+        token="$(gcloud auth print-access-token)"
+        api_base="https://${_REGION}-aiplatform.googleapis.com/v1"
+        verify_engine_exists() {
+          local engine_name="$1"
+          [ -z "$engine_name" ] && return 1
+          local status
+          status="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $$token" \
+            "$$api_base/$$engine_name")"
+          [ "$$status" = "200" ]
+        }
         AGENT_RESOURCE_NAME=$(gcloud secrets versions access latest \
           --secret=vuln-agent-resource-name 2>/dev/null || echo '')
         if [ -z "$$AGENT_RESOURCE_NAME" ]; then
           echo "vuln-agent-resource-name が未登録です。Scheduler のデプロイをスキップします。"
           exit 0
+        fi
+        if ! verify_engine_exists "$$AGENT_RESOURCE_NAME"; then
+          echo "vuln-agent-resource-name が不正です（ReasoningEngine が存在しません）: $$AGENT_RESOURCE_NAME"
+          echo "Scheduler のデプロイを中止します。"
+          exit 1
         fi
         echo "[Step 4/5] Scheduler を Cloud Functions にデプロイします"
         gcloud functions deploy vuln-agent-scheduler \


### PR DESCRIPTION
### Motivation
- Avoid saving or propagating stale/non-existent ReasoningEngine IDs which cause runtime 404 `The ReasoningEngine does not exist.` errors during redeploys. 
- Fail fast during CI/deploy so broken values in `vuln-agent-resource-name` do not reach Live Gateway or Scheduler services. 

### Description
- Added `verify_engine_exists` HTTP check in `cloudbuild.yaml` to validate candidate ReasoningEngine names before updating `vuln-agent-resource-name` and before deploying Live Gateway and Scheduler. 
- Added `_engine_exists` helper in `setup_cloud.sh` and use it to validate the `AGENT_RESOURCE_NAME` immediately after `adk deploy` output parsing and again before Live Gateway/Scheduler deployment. 
- When a check fails the deployment now skips secret updates or aborts with a clear error, preventing invalid IDs from being persisted or used at runtime. 

### Testing
- Ran `bash -n setup_cloud.sh` to validate shell syntax and it succeeded. 
- Parsed `cloudbuild.yaml` with `python` using `yaml.safe_load` to validate YAML structure and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ae86399c88325927c40771620e3ca)