### PR TITLE
docs: clarify AGENT_RESOURCE_NAME handling in scheduler deploy example

### DIFF
--- a/docs/SETUP_SCHEDULER.md
+++ b/docs/SETUP_SCHEDULER.md
@@ -74,6 +74,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 
 ### Step 3: Cloud Functions デプロイ
 
+`AGENT_RESOURCE_NAME` は `--set-env-vars` に含めず、Secret 参照（`--set-secrets`）のみを使用します。
+
 ```bash
 cd scheduler
 


### PR DESCRIPTION
### Motivation
- Make it explicit that `AGENT_RESOURCE_NAME` must not be provided via inline environment variables and should be supplied only via Secret Manager (`--set-secrets`) to avoid misconfiguration and leaking resource identifiers.

### Description
- Inserted a short note before the Cloud Functions deploy example stating that `AGENT_RESOURCE_NAME` should not be included in `--set-env-vars` and must be referenced via `--set-secrets` only, while keeping the `--remove-env-vars="AGENT_RESOURCE_NAME"` and `--set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest"` arguments consecutive in the example.

### Testing
- Verified with `rg -n '<<<<<<<|>>>>>>>|=======' docs/SETUP_SCHEDULER.md` and `rg -n -- '--set-env-vars=.*AGENT_RESOURCE_NAME' docs/SETUP_SCHEDULER.md` that there are no conflict markers and no inline `AGENT_RESOURCE_NAME` in `--set-env-vars`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698affa422c88325a46a888203ea5e29)