### PR TITLE
docs: fix scheduler redeploy command for secret-based AGENT_RESOURCE_NAME

### DIFF
--- a/docs/SETUP_SCHEDULER.md
+++ b/docs/SETUP_SCHEDULER.md
@@ -275,9 +275,13 @@ printf %s "projects/${PROJECT_ID}/locations/asia-northeast1/reasoningEngines/正
 
 # Secret 参照で再デプロイ
 gcloud functions deploy vuln-agent-scheduler \
+    --region=asia-northeast1 \
     --remove-env-vars="AGENT_RESOURCE_NAME" \
     --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest"
 ```
+
+> `AGENT_RESOURCE_NAME` を Secret 参照へ統一するため、再デプロイ時は
+> `--remove-env-vars` と `--set-secrets` を必ずセットで指定してください。
 
 ---
 


### PR DESCRIPTION
### Motivation
- Fix the "Secret 参照で再デプロイ" example to remove leftover conflict ambiguity and ensure redeploy uses the secret-based `AGENT_RESOURCE_NAME` configuration consistently.

### Description
- Updated `docs/SETUP_SCHEDULER.md` to keep both `--remove-env-vars="AGENT_RESOURCE_NAME"` and `--set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest"` in the redeploy example. 
- Added `--region=asia-northeast1` to the redeploy command for consistency with the main deploy example. 
- Added a short note instructing that `--remove-env-vars` and `--set-secrets` must be specified together when migrating `AGENT_RESOURCE_NAME` to a Secret reference.
- Verified the main deploy example in the same document already follows the same `--remove-env-vars` + `--set-secrets` pattern.

### Testing
- Ran `rg -n '<<<<<<<|=======|>>>>>>>' docs/SETUP_SCHEDULER.md` to ensure no conflict markers remain and it returned no matches. (succeeded)
- Ran `rg -n "gcloud functions deploy vuln-agent-scheduler|--remove-env-vars=\"AGENT_RESOURCE_NAME\"|--set-secrets=\"AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest\"" docs/SETUP_SCHEDULER.md` to confirm both flags exist in both examples. (succeeded)
- Inspected the changed file sections with `nl -ba docs/SETUP_SCHEDULER.md | sed -n '270,290p'` and `nl -ba docs/SETUP_SCHEDULER.md | sed -n '80,95p'` to confirm the `--region` addition and the explanatory note. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698affa5904c8325840ea13446e7ce0e)