### PR TITLE
Standardize secret success messages and clean Step 3.5 in setup_scheduler.sh

### DIFF
--- a/setup_scheduler.sh
+++ b/setup_scheduler.sh
@@ -155,13 +155,13 @@ if gcloud secrets describe "vuln-agent-resource-name" --project="$PROJECT_ID" &>
     echo -n "$AGENT_RESOURCE_NAME" | gcloud secrets versions add "vuln-agent-resource-name" \
         --data-file=- \
         --project="$PROJECT_ID" >/dev/null
-    print_success "vuln-agent-resource-name の新しいバージョンを追加しました"
+    print_success "既存シークレットに新しいバージョン追加: vuln-agent-resource-name"
 else
     echo -n "$AGENT_RESOURCE_NAME" | gcloud secrets create "vuln-agent-resource-name" \
         --data-file=- \
         --replication-policy="automatic" \
         --project="$PROJECT_ID" >/dev/null
-    print_success "vuln-agent-resource-name を作成しました"
+    print_success "シークレット作成: vuln-agent-resource-name"
 fi
 
 # ====================================


### PR DESCRIPTION
### Motivation
- Remove leftover conflict-marker concern in Step 3.5 and make success messages for Secret Manager operations explicit and consistent.

### Description
- Updated the `print_success` message after `gcloud secrets versions add` to `既存シークレットに新しいバージョン追加: vuln-agent-resource-name` without changing creation logic.
- Updated the `print_success` message after `gcloud secrets create` to `シークレット作成: vuln-agent-resource-name` without changing creation logic.
- Ensured the `if/else` block for `vuln-agent-resource-name` is clean and intact (no other logic modified).

### Testing
- Ran `rg -n '^(<<<<<<<|>>>>>>>|=======)$' setup_scheduler.sh` to confirm no conflict markers were present and it returned no matches (success).
- Inspected the relevant lines of `setup_scheduler.sh` (using `nl -ba`) to confirm the updated messages are present and no behavioral changes were introduced (success).
- Verified the patch application completed and only the message text in Step 3.5 changed by reviewing the diff output (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698affa9acec832590b4187e1debb487)