### PR TITLE
fix: Live Gateway デプロイ時の AGENT_RESOURCE_NAME 型競合を修正

### DIFF
--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -407,8 +407,9 @@ if [[ -n "$AGENT_RESOURCE_NAME" ]]; then
       --source=live_gateway \
       --region="$REGION" \
       --project="$PROJECT_ID" \
-      --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION},AGENT_RESOURCE_NAME=${AGENT_RESOURCE_NAME}" \
-      --set-secrets="GEMINI_API_KEY=vuln-agent-gemini-api-key:latest" \
+      --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION}" \
+      --remove-env-vars="AGENT_RESOURCE_NAME" \
+      --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest,GEMINI_API_KEY=vuln-agent-gemini-api-key:latest" \
       --service-account="$SA_EMAIL" \
       --allow-unauthenticated \
       --memory=512Mi \


### PR DESCRIPTION
## Summary

- `setup_cloud.sh` の Live Gateway デプロイで `AGENT_RESOURCE_NAME` を環境変数（文字列リテラル）として設定していたが、`cloudbuild.yaml` では Secret 参照として設定されるため、再デプロイ時に Cloud Run が型の不一致エラーを出していた
- Scheduler デプロイと同じパターン（`--remove-env-vars` + `--set-secrets`）に統一して修正

## Error

```
ERROR: (gcloud.run.deploy) Cannot update environment variable [AGENT_RESOURCE_NAME]
to string literal because it has already been set with a different type.
```

## Root Cause

| コンポーネント | ファイル | 設定方法 | 状態 |
|--------------|---------|---------|------|
| Live Gateway | `setup_cloud.sh:410` | `--set-env-vars` (文字列リテラル) | **修正前** |
| Live Gateway | `cloudbuild.yaml:173` | `--update-secrets` (Secret参照) | 正常 |
| Scheduler | `setup_cloud.sh:441-442` | `--remove-env-vars` + `--set-secrets` | 正常 |

Cloud Run は一度 Secret 参照として設定された変数を、文字列リテラルとして再設定できません。`setup_cloud.sh` と `cloudbuild.yaml` で設定方法が不一致だったため、2回目以降のデプロイでエラーが発生していました。

## Fix

```diff
- --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION},AGENT_RESOURCE_NAME=${AGENT_RESOURCE_NAME}"
- --set-secrets="GEMINI_API_KEY=vuln-agent-gemini-api-key:latest"
+ --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION}"
+ --remove-env-vars="AGENT_RESOURCE_NAME"
+ --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest,GEMINI_API_KEY=vuln-agent-gemini-api-key:latest"
```

## Test plan

- [ ] `bash setup_cloud.sh` を初回実行してデプロイが成功することを確認
- [ ] `bash setup_cloud.sh` を再実行して `AGENT_RESOURCE_NAME` の型競合エラーが発生しないことを確認
- [ ] `gcloud builds submit --config cloudbuild.yaml` で CI/CD パイプラインとの互換性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)