### PR TITLE
fix: Live Gatewayのenv-varsフラグ競合とSchedulerのIAM権限エラーを修正

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -206,7 +206,6 @@ steps:
           --source=scheduler \
           --entry-point=run_vulnerability_scan \
           --trigger-http \
-          --no-allow-unauthenticated \
           --service-account=vuln-agent-sa@${PROJECT_ID}.iam.gserviceaccount.com \
           --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${_REGION}" \
           --remove-env-vars="AGENT_RESOURCE_NAME" \

--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -407,9 +407,9 @@ if [[ -n "$AGENT_RESOURCE_NAME" ]]; then
       --source=live_gateway \
       --region="$REGION" \
       --project="$PROJECT_ID" \
-      --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION}" \
+      --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION}" \
       --remove-env-vars="AGENT_RESOURCE_NAME" \
-      --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest,GEMINI_API_KEY=vuln-agent-gemini-api-key:latest" \
+      --update-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest,GEMINI_API_KEY=vuln-agent-gemini-api-key:latest" \
       --service-account="$SA_EMAIL" \
       --allow-unauthenticated \
       --memory=512Mi \


### PR DESCRIPTION
## Summary

- `setup_cloud.sh` の Live Gateway デプロイで `--set-env-vars` と `--remove-env-vars` を同時指定していたフラグ競合を修正
- `cloudbuild.yaml` の Scheduler デプロイで `--no-allow-unauthenticated` が `run.services.setIamPolicy` を呼び、Cloud Build SA の権限不足で 403 エラーになる問題を修正

## Errors Fixed

**setup_cloud.sh 実行時:**
```
ERROR: (gcloud.run.deploy) argument --set-env-vars: At most one of
--clear-env-vars | --env-vars-file | --set-env-vars | --remove-env-vars --update-env-vars
can be specified.
```

**cloudbuild.yaml (git pull 自動デプロイ時):**
```
ERROR: (gcloud.functions.deploy) ResponseError: status=[403], code=[],
message=[Permission 'run.services.setIamPolicy' denied on resource
'projects/info-sec-ai-platform/locations/asia-northeast1/services/vuln-agent-scheduler']
```

## Root Cause & Fix

| エラー | 原因 | 修正 |
|--------|------|------|
| env-vars フラグ競合 | `--set-env-vars` は `--remove-env-vars` と排他的 | `--update-env-vars` / `--update-secrets` に変更 |
| setIamPolicy 403 | `--no-allow-unauthenticated` が setIamPolicy を呼ぶが Cloud Build SA に権限なし | フラグ削除（Gen2はデフォルトで認証必須のため影響なし） |

## Test plan

- [ ] `bash setup_cloud.sh` で Live Gateway デプロイが成功すること
- [ ] `gcloud builds submit --config cloudbuild.yaml` で Scheduler デプロイが成功すること
- [ ] Scheduler が認証なしではアクセスできないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)