### PR TITLE
fix: health check endpoint aliases for Cloud Run

### DIFF
--- a/live_gateway/app.py
+++ b/live_gateway/app.py
@@ -196,6 +196,24 @@ def healthz(request: Request):
     return {"status": "ok"}
 
 
+@app.get("/healthz/")
+def healthz_slash(request: Request):
+    logger.info("healthz called headers=%s", _safe_healthz_headers(request))
+    return {"status": "ok"}
+
+
+@app.get("/health")
+def health(request: Request):
+    logger.info("health called headers=%s", _safe_healthz_headers(request))
+    return {"status": "ok"}
+
+
+@app.get("/health/")
+def health_slash(request: Request):
+    logger.info("health called headers=%s", _safe_healthz_headers(request))
+    return {"status": "ok"}
+
+
 @app.get("/ping")
 def ping():
     return {"status": "ok"}

--- a/live_gateway/test_health_endpoints.py
+++ b/live_gateway/test_health_endpoints.py
@@ -1,0 +1,58 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+APP_FILE = Path(__file__).with_name("app.py")
+
+
+def _load_app_tree() -> ast.Module:
+    return ast.parse(APP_FILE.read_text(encoding="utf-8"))
+
+
+class HealthEndpointTests(unittest.TestCase):
+    def test_health_routes_are_declared(self):
+        tree = _load_app_tree()
+        expected_paths = {"/healthz", "/healthz/", "/health", "/health/"}
+        declared_paths: set[str] = set()
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                if not isinstance(dec.func, ast.Attribute):
+                    continue
+                if dec.func.attr != "get":
+                    continue
+                if not dec.args:
+                    continue
+                arg0 = dec.args[0]
+                if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+                    declared_paths.add(arg0.value)
+
+        self.assertTrue(
+            expected_paths.issubset(declared_paths),
+            f"missing endpoints: {sorted(expected_paths - declared_paths)}",
+        )
+
+    def test_healthz_header_filter_uses_allowlist(self):
+        tree = _load_app_tree()
+        target = None
+
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name == "_safe_healthz_headers":
+                target = node
+                break
+
+        self.assertIsNotNone(target, "_safe_healthz_headers function not found")
+
+        source = ast.get_source_segment(APP_FILE.read_text(encoding="utf-8"), target) or ""
+        self.assertIn("HEALTHZ_HEADER_ALLOWLIST", source)
+        self.assertIn("request.headers.items()", source)
+        self.assertIn("key.lower()", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
Cloud Run のヘルスチェック時にパス差異（`/healthz` 以外や末尾スラッシュ付き）で 404 になる取りこぼしを防ぐため、Live Gateway のヘルスチェックエンドポイントを補強しました。

## 変更点
- `live_gateway/app.py`
  - 既存の `/healthz` に加えて以下の互換エンドポイントを追加
    - `/healthz/`
    - `/health`
    - `/health/`
  - いずれも `{"status":"ok"}` を返却し、ヘッダーを安全にログ出力
- `live_gateway/test_health_endpoints.py`
  - ヘルスチェック用エンドポイントが4経路すべて宣言されていることを検証
  - `_safe_healthz_headers` が許可リストでフィルタリングしていることを検証

## テスト結果
- 実行コマンド: `python -m unittest live_gateway.test_health_endpoints -v`
- 結果: 2 tests, OK
