### PR TITLE
fix: escape BEFORE_SHA substitution in cloudbuild detect step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,10 +44,10 @@ steps:
 
         # 手動指定があれば _CHANGED_FILES を優先。未指定時は git diff で推定。
         if [ -z "$$changed_files_raw" ] && [ -d .git ] \
-          && [ -n "${BEFORE_SHA:-}" ] && [ -n "${COMMIT_SHA:-}" ]; then
+          && [ -n "$${BEFORE_SHA:-}" ] && [ -n "$${COMMIT_SHA:-}" ]; then
           zeros="0000000000000000000000000000000000000000"
-          if [ "${BEFORE_SHA}" != "$$zeros" ] && [ "${BEFORE_SHA}" != "${COMMIT_SHA}" ]; then
-            changed_files_raw="$(git diff --name-only "${BEFORE_SHA}" "${COMMIT_SHA}" || true)"
+          if [ "$$BEFORE_SHA" != "$$zeros" ] && [ "$$BEFORE_SHA" != "$$COMMIT_SHA" ]; then
+            changed_files_raw="$(git diff --name-only "$$BEFORE_SHA" "$$COMMIT_SHA" || true)"
           fi
         fi
 

--- a/test_cloudbuild_optimizations.py
+++ b/test_cloudbuild_optimizations.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import unittest
 
 
@@ -25,6 +26,10 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn("live_gateway/*)", self.content)
         self.assertIn("scheduler/*)", self.content)
         self.assertIn("web/*)", self.content)
+        self.assertIsNone(re.search(r"(?<!\$)\$\{BEFORE_SHA", self.content))
+        self.assertIsNone(re.search(r"(?<!\$)\$\{COMMIT_SHA", self.content))
+        self.assertIn("$${BEFORE_SHA:-}", self.content)
+        self.assertIn("$${COMMIT_SHA:-}", self.content)
 
     def test_agent_step_uses_adk_builder_and_skip_guard(self):
         self.assertIn('- name: "${_ADK_BUILDER_IMAGE}"', self.content)


### PR DESCRIPTION
## 概要
Cloud Build 実行時に `INVALID_ARGUMENT: ... "BEFORE_SHA" is not a valid built-in substitution` で失敗する不具合を修正しました。

## 原因
`cloudbuild.yaml` 内の Bash スクリプトで `${BEFORE_SHA}` / `${COMMIT_SHA}` をそのまま記述していたため、Cloud Build が置換テンプレートとして解釈し、未定義 substitution としてエラーになっていました。

## 変更点
- `cloudbuild.yaml`
  - `detect-changes` step の `BEFORE_SHA` / `COMMIT_SHA` 参照を Cloud Build 置換対象にならないようにエスケープ
  - 変更前: `${BEFORE_SHA}` / `${COMMIT_SHA}`
  - 変更後: `$$BEFORE_SHA`, `$$COMMIT_SHA`, `$${BEFORE_SHA:-}`, `$${COMMIT_SHA:-}`
- `test_cloudbuild_optimizations.py`
  - 未エスケープ `${BEFORE_SHA}` / `${COMMIT_SHA}` が混入していないことを検証するテストを追加

## テスト結果
- 実行コマンド: `python -m unittest test_cloudbuild_optimizations -v`
- 結果: 4 tests, OK
