### PR TITLE
fix: align FORCE_FULL_DEPLOY substitution with Cloud Build template

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,7 +39,8 @@ steps:
         DEPLOY_SCHEDULER=false
         DEPLOY_WEB=false
 
-        full_deploy="${_FORCE_FULL_DEPLOY,,}"
+        full_deploy_raw="${_FORCE_FULL_DEPLOY}"
+        full_deploy="$(printf '%s' "$$full_deploy_raw" | tr '[:upper:]' '[:lower:]')"
         changed_files_raw="${_CHANGED_FILES}"
 
         # 手動指定があれば _CHANGED_FILES を優先。未指定時は git diff で推定。

--- a/test_cloudbuild_optimizations.py
+++ b/test_cloudbuild_optimizations.py
@@ -15,6 +15,8 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn("_ADK_BUILDER_IMAGE:", self.content)
         self.assertIn("_FORCE_FULL_DEPLOY:", self.content)
         self.assertIn("_CHANGED_FILES:", self.content)
+        self.assertIn('${_FORCE_FULL_DEPLOY}', self.content)
+        self.assertNotIn('${_FORCE_FULL_DEPLOY,,}', self.content)
 
     def test_has_detect_changes_step(self):
         self.assertIn("id: detect-changes", self.content)


### PR DESCRIPTION
## 概要
Cloud Build 実行時に `key "_FORCE_FULL_DEPLOY" in the substitution data is not matched in the template` で失敗する不具合を修正しました。

## 原因
`cloudbuild.yaml` で `_FORCE_FULL_DEPLOY` を `${_FORCE_FULL_DEPLOY,,}` と Bash の lowercase 展開付きで参照していたため、Cloud Build 側が有効なテンプレート参照 `${_FORCE_FULL_DEPLOY}` として認識できず、未使用 substitution キー扱いになっていました。

## 変更点
- `cloudbuild.yaml`
  - `full_deploy` の取得を以下に変更
  - `full_deploy_raw="${_FORCE_FULL_DEPLOY}"`
  - `full_deploy="$(printf '%s' "$$full_deploy_raw" | tr '[:upper:]' '[:lower:]')"`
  - これによりテンプレート参照は Cloud Build 互換 (`${_FORCE_FULL_DEPLOY}`) を維持し、lowercase 化はシェルで実施
- `test_cloudbuild_optimizations.py`
  - `${_FORCE_FULL_DEPLOY}` が存在することを検証
  - `${_FORCE_FULL_DEPLOY,,}` が存在しないことを検証

## テスト結果
- 実行コマンド:
  - `python -m unittest test_cloudbuild_optimizations live_gateway.test_health_endpoints -v`
- 結果:
  - 6 tests, OK
