### PR TITLE
fix: wire Gmail/Chat env vars for agent connectivity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ echo -n "projects/xxx/locations/xxx/reasoningEngines/xxx" | \
 | シークレット名 | 用途 | 必須 |
 |---------------|------|------|
 | `vuln-agent-gmail-oauth-token` | Gmail OAuth トークン (Base64) | はい |
+| `vuln-agent-gmail-user-email` | Gmail ユーザーEmail（Workspace/ドメイン委任時） | いいえ |
 | `vuln-agent-sidfm-sender` | SIDfm 送信元メール | はい |
 | `vuln-agent-sbom-data-backend` | SBOM データソース (`sheets` / `bigquery` / `auto`) | いいえ (デフォルト: sheets) |
 | `vuln-agent-sbom-spreadsheet-id` | SBOM スプレッドシート ID | Sheets 利用時は必須 |

--- a/agent/tools/chat_tools.py
+++ b/agent/tools/chat_tools.py
@@ -77,7 +77,13 @@ def _get_chat_service():
 def _resolve_space_id(space_id: str | None = None) -> str | None:
     """スペースIDを解決する。未設定時はNoneを返す。"""
     if not space_id:
-        space_id = os.environ.get("DEFAULT_CHAT_SPACE_ID", "")
+        space_id = (
+            os.environ.get("DEFAULT_CHAT_SPACE_ID")
+            or os.environ.get("CHAT_SPACE_ID")
+            or os.environ.get("GOOGLE_CHAT_SPACE_ID")
+            or ""
+        )
+    space_id = space_id.strip()
     if not space_id:
         return None
     if not space_id.startswith("spaces/"):

--- a/agent/tools/gmail_tools.py
+++ b/agent/tools/gmail_tools.py
@@ -45,8 +45,12 @@ def _get_gmail_service():
         logger.info("Gmail service cache expired, re-initializing")
         _gmail_service = None
 
-    oauth_token = os.environ.get("GMAIL_OAUTH_TOKEN")
-    gmail_user = os.environ.get("GMAIL_USER_EMAIL")
+    oauth_token = (os.environ.get("GMAIL_OAUTH_TOKEN") or "").strip()
+    gmail_user = (
+        os.environ.get("GMAIL_USER_EMAIL")
+        or os.environ.get("GOOGLE_WORKSPACE_USER_EMAIL")
+        or ""
+    ).strip()
 
     credentials = None
     auth_method = "unknown"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -129,6 +129,7 @@ steps:
         echo "[Step 1/5] Secret Manager から .env を生成します"
         cat > agent/.env <<EOF
         GMAIL_OAUTH_TOKEN=$(gcloud secrets versions access latest --secret=vuln-agent-gmail-oauth-token 2>/dev/null || echo '')
+        GMAIL_USER_EMAIL=$(gcloud secrets versions access latest --secret=vuln-agent-gmail-user-email 2>/dev/null || echo '')
         SIDFM_SENDER_EMAIL=$(gcloud secrets versions access latest --secret=vuln-agent-sidfm-sender 2>/dev/null || echo 'noreply@sidfm.com')
         SBOM_DATA_BACKEND=$(gcloud secrets versions access latest --secret=vuln-agent-sbom-data-backend 2>/dev/null || echo 'sheets')
         SBOM_SPREADSHEET_ID=$(gcloud secrets versions access latest --secret=vuln-agent-sbom-spreadsheet-id 2>/dev/null || echo '')

--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -185,6 +185,7 @@ echo "  空欄で Enter を押すとその項目はスキップされます。"
 echo ""
 
 create_secret "vuln-agent-sidfm-sender"        "SIDfm 送信元メール"                       "noreply@sidfm.com"
+create_secret "vuln-agent-gmail-user-email"    "Gmail ユーザーEmail（Workspace任意）"
 create_secret "vuln-agent-sbom-data-backend"   "SBOM データソース (sheets/bigquery/auto)"     "sheets"
 create_secret "vuln-agent-sbom-spreadsheet-id" "SBOM スプレッドシート ID"
 create_secret "vuln-agent-sbom-sheet-name"     "SBOM シート名"                             "SBOM"
@@ -323,6 +324,7 @@ _wait_engine_ready() {
 
 cat > agent/.env <<ENVEOF
 GMAIL_OAUTH_TOKEN=$(_sm_get vuln-agent-gmail-oauth-token)
+GMAIL_USER_EMAIL=$(_sm_get vuln-agent-gmail-user-email)
 SIDFM_SENDER_EMAIL=$(_sm_get vuln-agent-sidfm-sender)
 SBOM_DATA_BACKEND=$(_sm_get vuln-agent-sbom-data-backend)
 SBOM_SPREADSHEET_ID=$(_sm_get vuln-agent-sbom-spreadsheet-id)

--- a/test_cloudbuild_optimizations.py
+++ b/test_cloudbuild_optimizations.py
@@ -17,6 +17,7 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn("_CHANGED_FILES:", self.content)
         self.assertIn('${_FORCE_FULL_DEPLOY}', self.content)
         self.assertNotIn('${_FORCE_FULL_DEPLOY,,}', self.content)
+        self.assertIn("--secret=vuln-agent-gmail-user-email", self.content)
 
     def test_has_detect_changes_step(self):
         self.assertIn("id: detect-changes", self.content)

--- a/test_connection_env_wiring.py
+++ b/test_connection_env_wiring.py
@@ -1,0 +1,82 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent
+CHAT_TOOLS_PATH = ROOT / "agent" / "tools" / "chat_tools.py"
+GMAIL_TOOLS_PATH = ROOT / "agent" / "tools" / "gmail_tools.py"
+SETUP_CLOUD_PATH = ROOT / "setup_cloud.sh"
+
+
+def _stub_google_modules() -> None:
+    google = types.ModuleType("google")
+    oauth2 = types.ModuleType("google.oauth2")
+    service_account = types.ModuleType("google.oauth2.service_account")
+
+    class _Creds:
+        @staticmethod
+        def from_service_account_file(*args, **kwargs):
+            return object()
+
+    service_account.Credentials = _Creds
+    oauth2.service_account = service_account
+    google.oauth2 = oauth2
+
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    discovery.build = lambda *args, **kwargs: object()
+    googleapiclient.discovery = discovery
+
+    sys.modules["google"] = google
+    sys.modules["google.oauth2"] = oauth2
+    sys.modules["google.oauth2.service_account"] = service_account
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class ConnectionEnvWiringTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _stub_google_modules()
+        cls.chat_tools = _load_module("chat_tools_test", CHAT_TOOLS_PATH)
+        cls.gmail_tools_source = GMAIL_TOOLS_PATH.read_text(encoding="utf-8")
+        cls.setup_cloud_source = SETUP_CLOUD_PATH.read_text(encoding="utf-8")
+
+    def setUp(self):
+        for key in ("DEFAULT_CHAT_SPACE_ID", "CHAT_SPACE_ID", "GOOGLE_CHAT_SPACE_ID"):
+            os.environ.pop(key, None)
+
+    def test_resolve_space_id_uses_default_env(self):
+        os.environ["DEFAULT_CHAT_SPACE_ID"] = "spaces/AAAA"
+        self.assertEqual(self.chat_tools._resolve_space_id(), "spaces/AAAA")
+
+    def test_resolve_space_id_supports_fallback_and_normalizes(self):
+        os.environ["CHAT_SPACE_ID"] = " BBBB "
+        self.assertEqual(self.chat_tools._resolve_space_id(), "spaces/BBBB")
+        os.environ.pop("CHAT_SPACE_ID", None)
+        os.environ["GOOGLE_CHAT_SPACE_ID"] = " spaces/CCCC "
+        self.assertEqual(self.chat_tools._resolve_space_id(), "spaces/CCCC")
+
+    def test_gmail_tools_supports_workspace_env_alias(self):
+        self.assertIn('os.environ.get("GMAIL_USER_EMAIL")', self.gmail_tools_source)
+        self.assertIn('os.environ.get("GOOGLE_WORKSPACE_USER_EMAIL")', self.gmail_tools_source)
+
+    def test_setup_cloud_has_gmail_user_secret(self):
+        self.assertIn("vuln-agent-gmail-user-email", self.setup_cloud_source)
+        self.assertIn("GMAIL_USER_EMAIL=$(_sm_get vuln-agent-gmail-user-email)", self.setup_cloud_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
Gmail/Chat 接続テストが失敗する原因を調査し、Agent Engine へ渡す環境変数の配線漏れと、Chat スペースID解決の堅牢性不足を修正しました。

## 原因
- `cloudbuild.yaml` と `setup_cloud.sh` の Agent 用 `.env` 生成に `GMAIL_USER_EMAIL` が含まれておらず、Workspace/ドメイン委任構成で Gmail 接続に失敗しうる状態でした。
- Chat 側は `DEFAULT_CHAT_SPACE_ID` のみ参照しており、環境変数名の差異や値の前後空白に弱く、未設定扱いになりうる状態でした。

## 変更点
- `cloudbuild.yaml`
  - Agent `.env` 生成時に `vuln-agent-gmail-user-email` Secret を追加し `GMAIL_USER_EMAIL` を注入
- `setup_cloud.sh`
  - Secret 作成項目に `vuln-agent-gmail-user-email` を追加
  - Agent `.env` 生成時に `GMAIL_USER_EMAIL` を追加
- `agent/tools/chat_tools.py`
  - スペースID解決で以下の順に参照
    - `DEFAULT_CHAT_SPACE_ID`
    - `CHAT_SPACE_ID`
    - `GOOGLE_CHAT_SPACE_ID`
  - 値を `strip()` して空白混入を吸収
- `agent/tools/gmail_tools.py`
  - `GMAIL_OAUTH_TOKEN`/`GMAIL_USER_EMAIL` の前後空白を除去
  - `GOOGLE_WORKSPACE_USER_EMAIL` を `GMAIL_USER_EMAIL` のエイリアスとして許容
- `README.md`
  - Secret 一覧に `vuln-agent-gmail-user-email` を追記

## テスト結果
- 実行コマンド:
  - `python -m unittest test_cloudbuild_optimizations test_connection_env_wiring live_gateway.test_health_endpoints -v`
- 結果:
  - 10 tests, OK

## 補足（完了条件の実機確認）
この作業環境では `GCP_PROJECT_ID` が未設定のため、`test_agent.sh` 実行は以下で失敗しました。
- `Error: GCP_PROJECT_ID が未設定です。gcloud config set project YOUR_PROJECT_ID を実行してください。`
