### PR TITLE
fix: load Gmail/Chat config from Secret Manager fallback

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -5,4 +5,5 @@ google-auth>=2.25.0
 google-auth-oauthlib>=1.2.0
 google-auth-httplib2>=0.2.0
 google-cloud-bigquery>=3.25.0
+google-cloud-secret-manager>=2.20.0
 packaging>=23.0

--- a/agent/tools/chat_tools.py
+++ b/agent/tools/chat_tools.py
@@ -13,6 +13,11 @@ from datetime import datetime, timedelta
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
+try:
+    from .secret_config import get_config_value
+except ImportError:
+    from secret_config import get_config_value
+
 logger = logging.getLogger(__name__)
 
 # 重大度設定
@@ -77,11 +82,10 @@ def _get_chat_service():
 def _resolve_space_id(space_id: str | None = None) -> str | None:
     """スペースIDを解決する。未設定時はNoneを返す。"""
     if not space_id:
-        space_id = (
-            os.environ.get("DEFAULT_CHAT_SPACE_ID")
-            or os.environ.get("CHAT_SPACE_ID")
-            or os.environ.get("GOOGLE_CHAT_SPACE_ID")
-            or ""
+        space_id = get_config_value(
+            ["DEFAULT_CHAT_SPACE_ID", "CHAT_SPACE_ID", "GOOGLE_CHAT_SPACE_ID"],
+            secret_name="vuln-agent-chat-space-id",
+            default="",
         )
     space_id = space_id.strip()
     if not space_id:

--- a/agent/tools/gmail_tools.py
+++ b/agent/tools/gmail_tools.py
@@ -18,6 +18,11 @@ from typing import Any
 
 from googleapiclient.discovery import build
 
+try:
+    from .secret_config import get_config_value
+except ImportError:
+    from secret_config import get_config_value
+
 logger = logging.getLogger(__name__)
 
 # Gmail APIサービスのキャッシュ
@@ -45,12 +50,16 @@ def _get_gmail_service():
         logger.info("Gmail service cache expired, re-initializing")
         _gmail_service = None
 
-    oauth_token = (os.environ.get("GMAIL_OAUTH_TOKEN") or "").strip()
-    gmail_user = (
-        os.environ.get("GMAIL_USER_EMAIL")
-        or os.environ.get("GOOGLE_WORKSPACE_USER_EMAIL")
-        or ""
-    ).strip()
+    oauth_token = get_config_value(
+        ["GMAIL_OAUTH_TOKEN"],
+        secret_name="vuln-agent-gmail-oauth-token",
+        default="",
+    )
+    gmail_user = get_config_value(
+        ["GMAIL_USER_EMAIL", "GOOGLE_WORKSPACE_USER_EMAIL"],
+        secret_name="vuln-agent-gmail-user-email",
+        default="",
+    )
 
     credentials = None
     auth_method = "unknown"

--- a/agent/tools/secret_config.py
+++ b/agent/tools/secret_config.py
@@ -1,0 +1,70 @@
+import logging
+import os
+from typing import Iterable
+
+import google.auth
+from google.cloud import secretmanager
+
+logger = logging.getLogger(__name__)
+
+_secret_cache: dict[tuple[str, str], str] = {}
+_project_id_cache: str | None = None
+
+
+def _resolve_project_id() -> str | None:
+    global _project_id_cache
+    if _project_id_cache:
+        return _project_id_cache
+
+    env_project = (os.environ.get("GCP_PROJECT_ID") or "").strip()
+    if env_project:
+        _project_id_cache = env_project
+        return _project_id_cache
+
+    try:
+        _, detected_project = google.auth.default()
+        _project_id_cache = (detected_project or "").strip() or None
+    except Exception as exc:
+        logger.warning("Could not detect GCP project for Secret Manager fallback: %s", exc)
+        _project_id_cache = None
+    return _project_id_cache
+
+
+def _get_secret_value(secret_name: str) -> str:
+    project_id = _resolve_project_id()
+    if not project_id:
+        return ""
+
+    key = (project_id, secret_name)
+    if key in _secret_cache:
+        return _secret_cache[key]
+
+    try:
+        client = secretmanager.SecretManagerServiceClient()
+        name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        value = response.payload.data.decode("utf-8").strip()
+        _secret_cache[key] = value
+        return value
+    except Exception as exc:
+        logger.warning("Secret Manager fallback failed for %s: %s", secret_name, exc)
+        _secret_cache[key] = ""
+        return ""
+
+
+def get_config_value(
+    env_names: Iterable[str],
+    secret_name: str | None = None,
+    default: str = "",
+) -> str:
+    for env_name in env_names:
+        value = (os.environ.get(env_name) or "").strip()
+        if value:
+            return value
+
+    if secret_name:
+        secret_value = _get_secret_value(secret_name)
+        if secret_value:
+            return secret_value
+
+    return default

--- a/test_secret_config.py
+++ b/test_secret_config.py
@@ -1,0 +1,90 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+SECRET_CONFIG_PATH = Path("agent/tools/secret_config.py")
+
+
+def _load_secret_config_module():
+    spec = importlib.util.spec_from_file_location("secret_config_test", SECRET_CONFIG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class SecretConfigTests(unittest.TestCase):
+    def setUp(self):
+        self._tracked_keys = [
+            "google",
+            "google.auth",
+            "google.cloud",
+            "google.cloud.secretmanager",
+            "secret_config_test",
+        ]
+        self._orig_modules = {k: sys.modules.get(k) for k in self._tracked_keys}
+        self._orig_env = dict(os.environ)
+
+    def tearDown(self):
+        for key in self._tracked_keys:
+            if self._orig_modules[key] is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = self._orig_modules[key]
+        os.environ.clear()
+        os.environ.update(self._orig_env)
+
+    def test_prefers_env_value(self):
+        google = types.ModuleType("google")
+        auth = types.ModuleType("google.auth")
+        auth.default = lambda: (object(), "dummy-project")
+        cloud = types.ModuleType("google.cloud")
+        secretmanager = types.ModuleType("google.cloud.secretmanager")
+        secretmanager.SecretManagerServiceClient = object
+        cloud.secretmanager = secretmanager
+        google.auth = auth
+        google.cloud = cloud
+        sys.modules["google"] = google
+        sys.modules["google.auth"] = auth
+        sys.modules["google.cloud"] = cloud
+        sys.modules["google.cloud.secretmanager"] = secretmanager
+
+        mod = _load_secret_config_module()
+        os.environ["TEST_ENV"] = " env-value "
+        value = mod.get_config_value(["TEST_ENV"], secret_name="dummy-secret", default="x")
+        self.assertEqual(value, "env-value")
+
+    def test_uses_secret_when_env_missing(self):
+        google = types.ModuleType("google")
+        auth = types.ModuleType("google.auth")
+        auth.default = lambda: (object(), "dummy-project")
+
+        class _Client:
+            def access_secret_version(self, request):
+                self.last_name = request["name"]
+                payload = types.SimpleNamespace(data=b" secret-value ")
+                return types.SimpleNamespace(payload=payload)
+
+        cloud = types.ModuleType("google.cloud")
+        secretmanager = types.ModuleType("google.cloud.secretmanager")
+        secretmanager.SecretManagerServiceClient = _Client
+        cloud.secretmanager = secretmanager
+        google.auth = auth
+        google.cloud = cloud
+
+        sys.modules["google"] = google
+        sys.modules["google.auth"] = auth
+        sys.modules["google.cloud"] = cloud
+        sys.modules["google.cloud.secretmanager"] = secretmanager
+
+        mod = _load_secret_config_module()
+        value = mod.get_config_value(["MISSING_ENV"], secret_name="my-secret", default="x")
+        self.assertEqual(value, "secret-value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
Agent Engine 実行時に環境変数が未注入でも Gmail/Chat 設定を Secret Manager から取得できるようにしました。

## 変更点
- gent/tools/secret_config.py を追加（env -> Secret Manager fallback）
- gent/tools/gmail_tools.py と gent/tools/chat_tools.py で fallback 利用
- gent/requirements.txt に google-cloud-secret-manager を追加
- テスト追加・更新（	est_secret_config.py, 	est_connection_env_wiring.py）

## テスト
python -m unittest test_secret_config test_connection_env_wiring test_cloudbuild_optimizations live_gateway.test_health_endpoints -v
- 13 tests, OK