### PR TITLE
fix: add one-command scripts to toggle Live Gateway public access

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,27 @@ gcloud builds triggers create github \
 
 デプロイ後の日常運用で使うコマンドです。すべて Cloud Shell で実行できます。
 
+### Live Gateway を一時公開/非公開に切り替える（1コマンド）
+
+リアルタイム対話のテスト時だけ `allUsers` 公開し、終了後に閉じる運用用スクリプトです。
+
+```bash
+# 公開ON
+bash scripts/gateway-open.sh
+
+# 公開OFF
+bash scripts/gateway-close.sh
+
+# 現在のIAM確認
+bash scripts/gateway-access.sh status
+```
+
+必要に応じて環境変数でサービス名/リージョンを上書きできます。
+
+```bash
+SERVICE_NAME=vuln-agent-live-gateway REGION=asia-northeast1 bash scripts/gateway-open.sh
+```
+
 ### git pull 後に自動デプロイする（Cloud Shell 推奨）
 
 Cloud Shell で `git pull` したタイミングで、対象ファイル変更があれば

--- a/scripts/gateway-access.sh
+++ b/scripts/gateway-access.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_NAME="${SERVICE_NAME:-vuln-agent-live-gateway}"
+REGION="${REGION:-asia-northeast1}"
+ROLE="roles/run.invoker"
+MEMBER="allUsers"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/gateway-access.sh open
+  bash scripts/gateway-access.sh close
+  bash scripts/gateway-access.sh status
+
+Optional environment variables:
+  SERVICE_NAME (default: vuln-agent-live-gateway)
+  REGION       (default: asia-northeast1)
+EOF
+}
+
+status() {
+  gcloud run services get-iam-policy "${SERVICE_NAME}" \
+    --region="${REGION}" \
+    --format="table(bindings.role,bindings.members)"
+}
+
+open_gateway() {
+  echo "[gateway-access] Opening public access for ${SERVICE_NAME} (${REGION})..."
+  gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
+    --region="${REGION}" \
+    --member="${MEMBER}" \
+    --role="${ROLE}" >/dev/null
+  echo "[gateway-access] Public access enabled."
+  status
+}
+
+close_gateway() {
+  echo "[gateway-access] Closing public access for ${SERVICE_NAME} (${REGION})..."
+  gcloud run services remove-iam-policy-binding "${SERVICE_NAME}" \
+    --region="${REGION}" \
+    --member="${MEMBER}" \
+    --role="${ROLE}" >/dev/null
+  echo "[gateway-access] Public access disabled."
+  status
+}
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud command not found. Install Google Cloud CLI first." >&2
+  exit 1
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  open)
+    open_gateway
+    ;;
+  close)
+    close_gateway
+    ;;
+  status)
+    status
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/gateway-close.sh
+++ b/scripts/gateway-close.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash "$(dirname "$0")/gateway-access.sh" close

--- a/scripts/gateway-open.sh
+++ b/scripts/gateway-open.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bash "$(dirname "$0")/gateway-access.sh" open


### PR DESCRIPTION
## Summary
- add Cloud Shell scripts to toggle uln-agent-live-gateway public access with one command
- add open, close, and status commands under scripts/
- document usage in README operational commands section

## Changes
- added scripts/gateway-access.sh
- added scripts/gateway-open.sh
- added scripts/gateway-close.sh
- updated README.md with usage examples and optional env overrides

## Test Results
- ash -n scripts/gateway-access.sh : passed
- ash -n scripts/gateway-open.sh : passed
- ash -n scripts/gateway-close.sh : passed