### PR TITLE
fix: improve chat textarea layout and autosize behavior

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -500,6 +500,16 @@ stopAudioButton.addEventListener("click", async () => {
 });
 
 // ── Chat Form ───────────────────────────────────────────
+function resizeChatInput() {
+  chatInput.style.height = "auto";
+  const maxHeight = 180;
+  const nextHeight = Math.min(chatInput.scrollHeight, maxHeight);
+  chatInput.style.height = `${nextHeight}px`;
+  chatInput.style.overflowY = chatInput.scrollHeight > maxHeight ? "auto" : "hidden";
+}
+
+chatInput.addEventListener("input", resizeChatInput);
+
 chatInput.addEventListener("keydown", (event) => {
   if (event.isComposing || event.keyCode === 229) return;
   if (event.key !== "Enter") return;
@@ -521,6 +531,7 @@ chatForm.addEventListener("submit", (event) => {
   appendMessage(message, "user");
   socket.send(JSON.stringify({ type: "user_text", text: message }));
   chatInput.value = "";
+  resizeChatInput();
   resetLiveTextBubble();
 });
 
@@ -566,4 +577,5 @@ function playAudio(base64Audio, mimeType) {
 // ── Initialize ──────────────────────────────────────────
 setStatus(false, "Disconnected");
 setMode("idle");
+resizeChatInput();
 renderIcons();

--- a/web/style.css
+++ b/web/style.css
@@ -483,6 +483,7 @@ body {
 /* ── Chat Input Form ─────────────────────────── */
 .chat-input-form {
   display: flex;
+  align-items: flex-end;
   gap: 10px;
   padding-top: 10px;
   border-top: 1px solid var(--border-primary);
@@ -490,19 +491,27 @@ body {
 
 .chat-input-form textarea {
   flex: 1;
+  width: 100%;
+  min-width: 0;
   padding: 12px 14px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border-primary);
   background: var(--bg-input);
   color: var(--text-primary);
+  appearance: none;
+  -webkit-appearance: none;
   font-family: var(--font-family);
   font-size: var(--font-sm);
   line-height: 1.4;
-  min-height: 44px;
+  min-height: 46px;
   max-height: 180px;
-  resize: vertical;
+  resize: none;
   overflow-y: auto;
   transition: border-color var(--transition-fast);
+}
+
+.chat-input-form textarea::placeholder {
+  color: var(--text-muted);
 }
 
 .chat-input-form textarea:focus {


### PR DESCRIPTION
## Summary
- fix chat textarea layout issues in the bottom input bar
- improve cross-browser textarea styling consistency
- add autosize behavior so Shift+Enter multi-line input remains readable

## Changes
- set textarea width: 100% and min-width: 0 in flex layout
- align input row items to bottom for stable visual alignment
- disable manual textarea resize handle and use controlled autosize
- tune minimum height and placeholder color for readability
- add esizeChatInput() in frontend JS and trigger on input/submit/init

## Validation
- 
ode --check web/app.js passed