### PR TITLE
fix: harden frontend connection UX, input handling, and runtime stability

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -17,12 +17,19 @@ const audioStatusText = document.getElementById("audio-status");
 const audioLevelBar = document.getElementById("audio-level-bar");
 const activityFeed = document.getElementById("activity-feed");
 const clearActivityButton = document.getElementById("clear-activity");
+const pingLatencyText = document.getElementById("ping-latency");
+const reconnectCountText = document.getElementById("reconnect-count");
+const toastContainer = document.getElementById("toast-container");
+const sendButton = chatForm.querySelector('button[type="submit"]');
 
 // ── Audio Detection Constants ───────────────────────────
 const RMS_SPEECH_THRESHOLD = 0.025;
 const RMS_SILENCE_THRESHOLD = 0.012;
 const RMS_SMOOTHING = 0.2;
 const PAUSE_TRIGGER_MS = 650;
+const MAX_RENDERED_MESSAGES = 200;
+const HEALTH_PING_INTERVAL_MS = 30000;
+const GATEWAY_URL_STORAGE_KEY = "vuln_agent_gateway_url";
 
 // ── State ───────────────────────────────────────────────
 let socket = null;
@@ -39,6 +46,12 @@ let isLiveSessionActive = false;
 let hasSocketError = false;
 let liveTextBubble = null;
 let socketGeneration = 0;
+let healthPingIntervalId = null;
+let reconnectCount = 0;
+let hasEverConnected = false;
+let manualDisconnectRequested = false;
+let isRequestInFlight = false;
+let audioCaptureNode = null;
 
 // ── Utility Functions ───────────────────────────────────
 function escapeHtml(str) {
@@ -61,6 +74,95 @@ function renderIcons(root) {
   }
 }
 
+function showToast(message, kind = "info", timeoutMs = 4000) {
+  if (!toastContainer) return;
+  const toast = document.createElement("div");
+  toast.className = `toast toast-${kind}`;
+  toast.textContent = message;
+  toastContainer.appendChild(toast);
+  window.setTimeout(() => {
+    toast.remove();
+  }, timeoutMs);
+}
+
+function pruneMessages() {
+  const messages = messagesArea.querySelectorAll(".message");
+  if (messages.length <= MAX_RENDERED_MESSAGES) return;
+  let toRemove = messages.length - MAX_RENDERED_MESSAGES;
+  for (const node of messages) {
+    if (toRemove <= 0) break;
+    if (node === liveTextBubble) liveTextBubble = null;
+    if (node === thinkingBubble) thinkingBubble = null;
+    node.remove();
+    toRemove--;
+  }
+}
+
+function setRequestInFlight(nextState) {
+  isRequestInFlight = nextState;
+  sendButton.disabled = nextState || !socket || socket.readyState !== WebSocket.OPEN;
+  chatInput.disabled = nextState || !socket || socket.readyState !== WebSocket.OPEN;
+}
+
+function updateHealthMetrics(latencyMs = null) {
+  if (pingLatencyText) {
+    pingLatencyText.textContent = latencyMs == null ? "Ping: -- ms" : `Ping: ${latencyMs} ms`;
+  }
+  if (reconnectCountText) {
+    reconnectCountText.textContent = `Reconnects: ${reconnectCount}`;
+  }
+}
+
+function parseGatewayBaseHttpUrl(rawWsUrl) {
+  try {
+    const parsed = new URL(rawWsUrl);
+    if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") return null;
+    const nextProtocol = parsed.protocol === "wss:" ? "https:" : "http:";
+    return `${nextProtocol}//${parsed.host}`;
+  } catch {
+    return null;
+  }
+}
+
+async function runHealthPing() {
+  const wsUrl = gatewayInput.value.trim();
+  const baseUrl = parseGatewayBaseHttpUrl(wsUrl);
+  if (!baseUrl) {
+    updateHealthMetrics(null);
+    return;
+  }
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(`${baseUrl}/ping`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      updateHealthMetrics(null);
+      return;
+    }
+    const latency = Math.max(1, Math.round(performance.now() - startedAt));
+    updateHealthMetrics(latency);
+  } catch {
+    updateHealthMetrics(null);
+  }
+}
+
+function stopHealthPingLoop() {
+  if (healthPingIntervalId != null) {
+    window.clearInterval(healthPingIntervalId);
+    healthPingIntervalId = null;
+  }
+}
+
+function startHealthPingLoop() {
+  stopHealthPingLoop();
+  void runHealthPing();
+  healthPingIntervalId = window.setInterval(() => {
+    void runHealthPing();
+  }, HEALTH_PING_INTERVAL_MS);
+}
+
 // ── Connection Status ───────────────────────────────────
 function setStatus(online, message) {
   statusIndicator.classList.toggle("online", online);
@@ -69,6 +171,8 @@ function setStatus(online, message) {
   disconnectButton.disabled = !online;
   startAudioButton.disabled = !online;
   stopAudioButton.disabled = true;
+  sendButton.disabled = !online || isRequestInFlight;
+  chatInput.disabled = isRequestInFlight;
 }
 
 // ── Audio Mode ──────────────────────────────────────────
@@ -107,6 +211,7 @@ function appendMessage(text, type) {
   `;
 
   messagesArea.appendChild(bubble);
+  pruneMessages();
   messagesArea.scrollTop = messagesArea.scrollHeight;
   renderIcons(bubble);
 }
@@ -128,6 +233,7 @@ function appendLiveText(text) {
       </div>
     `;
     messagesArea.appendChild(bubble);
+    pruneMessages();
     renderIcons(bubble);
     liveTextBubble = bubble;
   }
@@ -190,6 +296,7 @@ function handleAgentActivity(payload) {
   }
 
   if (activity === "done") {
+    setRequestInFlight(false);
     addActivityItem("done", icon || "check-circle-2", message, false);
     return;
   }
@@ -227,6 +334,12 @@ async function stopAudioCapture(sendLiveStop = false) {
     processor.disconnect();
     processor.onaudioprocess = null;
   }
+  if (audioCaptureNode) {
+    audioCaptureNode.disconnect();
+    if (audioCaptureNode.port && audioCaptureNode.port.onmessage) {
+      audioCaptureNode.port.onmessage = null;
+    }
+  }
   if (mediaStream) {
     mediaStream.getTracks().forEach((track) => track.stop());
   }
@@ -235,6 +348,7 @@ async function stopAudioCapture(sendLiveStop = false) {
   }
 
   processor = null;
+  audioCaptureNode = null;
   mediaStream = null;
   audioContext = null;
   audioLevelBar.style.width = "0%";
@@ -301,18 +415,115 @@ function markLastToolComplete(success) {
   }
 }
 
+function encodePcmToBase64(floatSamples) {
+  const int16 = new Int16Array(floatSamples.length);
+  for (let i = 0; i < floatSamples.length; i++) {
+    int16[i] = Math.max(-1, Math.min(1, floatSamples[i])) * 0x7fff;
+  }
+  const bytes = new Uint8Array(int16.buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function sendAudioChunk(floatSamples, sampleRate) {
+  if (!socket || socket.readyState !== WebSocket.OPEN) return;
+  socket.send(
+    JSON.stringify({
+      type: "audio_chunk",
+      audio: encodePcmToBase64(floatSamples),
+      sample_rate: sampleRate,
+    }),
+  );
+}
+
+async function setupAudioCaptureNode(source, context) {
+  if (typeof AudioWorkletNode === "undefined" || !context.audioWorklet) {
+    return false;
+  }
+  const processorCode = `
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || !input[0]) return true;
+    this.port.postMessage(input[0]);
+    return true;
+  }
+}
+registerProcessor("pcm-capture-processor", PcmCaptureProcessor);
+`;
+  const blob = new Blob([processorCode], { type: "application/javascript" });
+  const moduleUrl = URL.createObjectURL(blob);
+  try {
+    await context.audioWorklet.addModule(moduleUrl);
+    const workletNode = new AudioWorkletNode(context, "pcm-capture-processor", {
+      numberOfInputs: 1,
+      numberOfOutputs: 0,
+    });
+    workletNode.port.onmessage = (event) => {
+      const input = event.data;
+      if (!(input instanceof Float32Array)) return;
+      const rms = Math.sqrt(input.reduce((sum, value) => sum + value * value, 0) / input.length);
+      smoothedRms = RMS_SMOOTHING * rms + (1 - RMS_SMOOTHING) * smoothedRms;
+      updateAudioLevel(smoothedRms);
+      const now = Date.now();
+      if (smoothedRms > RMS_SPEECH_THRESHOLD) {
+        lastSpeechTimestamp = now;
+        if (mode !== "listening") setMode("listening");
+        if (currentPlaybackSource) {
+          currentPlaybackSource.stop();
+          currentPlaybackSource = null;
+          if (socket && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: "barge_in" }));
+          }
+        }
+      }
+      if (
+        smoothedRms < RMS_SILENCE_THRESHOLD &&
+        lastSpeechTimestamp !== 0 &&
+        now - lastSpeechTimestamp > PAUSE_TRIGGER_MS
+      ) {
+        if (socket && socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify({ type: "speech_pause" }));
+        }
+        lastSpeechTimestamp = 0;
+      }
+      sendAudioChunk(input, context.sampleRate);
+    };
+    source.connect(workletNode);
+    audioCaptureNode = workletNode;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    URL.revokeObjectURL(moduleUrl);
+  }
+}
+
 // ── Clear Activity Button ───────────────────────────────
 clearActivityButton.addEventListener("click", () => {
   resetActivityFeed();
 });
 
 // ── WebSocket Connection ────────────────────────────────
+gatewayInput.addEventListener("change", () => {
+  const value = gatewayInput.value.trim();
+  if (value) {
+    window.localStorage.setItem(GATEWAY_URL_STORAGE_KEY, value);
+  }
+});
+
 connectButton.addEventListener("click", () => {
   const url = gatewayInput.value.trim();
   if (!url) {
+    showToast("Gateway URL を入力してください。", "warning");
     appendMessage("Gateway URL を入力してください。", "system");
     return;
   }
+  manualDisconnectRequested = false;
+  window.localStorage.setItem(GATEWAY_URL_STORAGE_KEY, url);
   const myGeneration = ++socketGeneration;
   if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
     socket.close();
@@ -323,11 +534,17 @@ connectButton.addEventListener("click", () => {
 
   ws.addEventListener("open", () => {
     if (socket !== ws || myGeneration !== socketGeneration) return;
+    if (hasEverConnected) reconnectCount++;
+    hasEverConnected = true;
     hasSocketError = false;
     isLiveSessionActive = false;
     resetLiveTextBubble();
     setStatus(true, "Connected");
+    setRequestInFlight(false);
+    startHealthPingLoop();
+    updateHealthMetrics(null);
     appendMessage("接続しました。", "system");
+    showToast("Live Gateway に接続しました。", "success", 2500);
   });
 
   ws.addEventListener("message", (event) => {
@@ -342,6 +559,7 @@ connectButton.addEventListener("click", () => {
 
       if (payload.type === "agent_response") {
         hideThinking();
+        setRequestInFlight(false);
         if (!isLiveSessionActive) {
           appendMessage(payload.text || "(no response)", "agent");
         }
@@ -375,6 +593,8 @@ connectButton.addEventListener("click", () => {
       }
 
       if (payload.type === "error") {
+        setRequestInFlight(false);
+        showToast(payload.message || "Gateway error", "error");
         appendMessage(payload.message || "Error", "system");
         return;
       }
@@ -392,26 +612,38 @@ connectButton.addEventListener("click", () => {
   ws.addEventListener("close", () => {
     if (myGeneration !== socketGeneration) return;
     void stopAudioCapture(false);
+    stopHealthPingLoop();
     const wasError = hasSocketError;
     hasSocketError = false;
     isLiveSessionActive = false;
+    setRequestInFlight(false);
     resetLiveTextBubble();
     if (socket === ws) {
       socket = null;
     }
     setStatus(false, "Disconnected");
+    updateHealthMetrics(null);
     setMode("idle");
-    appendMessage(wasError ? "接続エラーで切断しました。" : "切断しました。", "system");
+    appendMessage(
+      wasError ? "接続エラーで切断しました。" : manualDisconnectRequested ? "手動で切断しました。" : "切断しました。",
+      "system",
+    );
+    if (wasError) {
+      showToast("接続エラーが発生しました。Gateway URL と公開設定を確認してください。", "error");
+    }
+    manualDisconnectRequested = false;
   });
 
   ws.addEventListener("error", () => {
     if (socket !== ws || myGeneration !== socketGeneration) return;
     hasSocketError = true;
+    setRequestInFlight(false);
     setStatus(false, "Error");
   });
 });
 
 disconnectButton.addEventListener("click", () => {
+  manualDisconnectRequested = true;
   if (socket) {
     socket.close();
   }
@@ -428,69 +660,54 @@ startAudioButton.addEventListener("click", async () => {
     mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
     audioContext = new AudioContext();
     const source = audioContext.createMediaStreamSource(mediaStream);
-    processor = audioContext.createScriptProcessor(4096, 1, 1);
+    const workletReady = await setupAudioCaptureNode(source, audioContext);
+    if (!workletReady) {
+      processor = audioContext.createScriptProcessor(4096, 1, 1);
+      processor.onaudioprocess = (event) => {
+        const input = event.inputBuffer.getChannelData(0);
+        const rms = Math.sqrt(
+          input.reduce((sum, value) => sum + value * value, 0) / input.length,
+        );
+        smoothedRms = RMS_SMOOTHING * rms + (1 - RMS_SMOOTHING) * smoothedRms;
+        updateAudioLevel(smoothedRms);
 
-    processor.onaudioprocess = (event) => {
-      const input = event.inputBuffer.getChannelData(0);
-      const rms = Math.sqrt(
-        input.reduce((sum, value) => sum + value * value, 0) / input.length,
-      );
-      smoothedRms = RMS_SMOOTHING * rms + (1 - RMS_SMOOTHING) * smoothedRms;
-      updateAudioLevel(smoothedRms);
-
-      const now = Date.now();
-      if (smoothedRms > RMS_SPEECH_THRESHOLD) {
-        lastSpeechTimestamp = now;
-        if (mode !== "listening") {
-          setMode("listening");
-        }
-        if (currentPlaybackSource) {
-          currentPlaybackSource.stop();
-          currentPlaybackSource = null;
-          if (socket && socket.readyState === WebSocket.OPEN) {
-            socket.send(JSON.stringify({ type: "barge_in" }));
+        const now = Date.now();
+        if (smoothedRms > RMS_SPEECH_THRESHOLD) {
+          lastSpeechTimestamp = now;
+          if (mode !== "listening") {
+            setMode("listening");
+          }
+          if (currentPlaybackSource) {
+            currentPlaybackSource.stop();
+            currentPlaybackSource = null;
+            if (socket && socket.readyState === WebSocket.OPEN) {
+              socket.send(JSON.stringify({ type: "barge_in" }));
+            }
           }
         }
-      }
-      if (
-        smoothedRms < RMS_SILENCE_THRESHOLD &&
-        lastSpeechTimestamp !== 0 &&
-        now - lastSpeechTimestamp > PAUSE_TRIGGER_MS
-      ) {
-        if (socket && socket.readyState === WebSocket.OPEN) {
-          socket.send(JSON.stringify({ type: "speech_pause" }));
+        if (
+          smoothedRms < RMS_SILENCE_THRESHOLD &&
+          lastSpeechTimestamp !== 0 &&
+          now - lastSpeechTimestamp > PAUSE_TRIGGER_MS
+        ) {
+          if (socket && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: "speech_pause" }));
+          }
+          lastSpeechTimestamp = 0;
         }
-        lastSpeechTimestamp = 0;
-      }
+        sendAudioChunk(input, audioContext.sampleRate);
+      };
+      source.connect(processor);
+      processor.connect(audioContext.destination);
+      showToast("AudioWorklet 非対応のため互換モードで録音します。", "warning", 2500);
+    }
 
-      const int16 = new Int16Array(input.length);
-      for (let i = 0; i < input.length; i++) {
-        int16[i] = Math.max(-1, Math.min(1, input[i])) * 0x7fff;
-      }
-      const bytes = new Uint8Array(int16.buffer);
-      let binary = '';
-      for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-      }
-      const base64 = btoa(binary);
-      if (socket && socket.readyState === WebSocket.OPEN) {
-        socket.send(
-          JSON.stringify({
-            type: "audio_chunk",
-            audio: base64,
-            sample_rate: audioContext.sampleRate,
-          }),
-        );
-      }
-    };
-
-    source.connect(processor);
-    processor.connect(audioContext.destination);
     socket.send(JSON.stringify({ type: "live_start" }));
     setMode("listening");
     startAudioButton.disabled = true;
     stopAudioButton.disabled = false;
   } catch (err) {
+    showToast(`音声開始に失敗しました: ${err.message}`, "error");
     appendMessage(`音声開始に失敗しました: ${err.message}`, "system");
   }
 });
@@ -520,7 +737,9 @@ chatInput.addEventListener("keydown", (event) => {
 
 chatForm.addEventListener("submit", (event) => {
   event.preventDefault();
+  if (isRequestInFlight) return;
   if (!socket || socket.readyState !== WebSocket.OPEN) {
+    showToast("接続してから送信してください。", "warning");
     appendMessage("接続してから送信してください。", "system");
     return;
   }
@@ -529,6 +748,7 @@ chatForm.addEventListener("submit", (event) => {
   if (!message) return;
 
   appendMessage(message, "user");
+  setRequestInFlight(true);
   socket.send(JSON.stringify({ type: "user_text", text: message }));
   chatInput.value = "";
   resizeChatInput();
@@ -575,7 +795,15 @@ function playAudio(base64Audio, mimeType) {
 }
 
 // ── Initialize ──────────────────────────────────────────
+const savedGatewayUrl = window.localStorage.getItem(GATEWAY_URL_STORAGE_KEY);
+if (savedGatewayUrl) {
+  gatewayInput.value = savedGatewayUrl;
+}
 setStatus(false, "Disconnected");
 setMode("idle");
+updateHealthMetrics(null);
 resizeChatInput();
+window.addEventListener("beforeunload", () => {
+  stopHealthPingLoop();
+});
 renderIcons();

--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,10 @@
             <span class="connection-dot" id="status-indicator"></span>
             <span class="connection-label" id="status-text">Disconnected</span>
           </div>
+          <div class="connection-metrics">
+            <span id="ping-latency">Ping: -- ms</span>
+            <span id="reconnect-count">Reconnects: 0</span>
+          </div>
         </div>
       </header>
 
@@ -112,6 +116,7 @@
         </section>
       </div>
     </div>
+    <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
 
     <script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
     <script src="app.js"></script>

--- a/web/style.css
+++ b/web/style.css
@@ -110,6 +110,7 @@ body {
 .header-right {
   display: flex;
   align-items: center;
+  gap: 12px;
 }
 
 /* ── Connection Badge ────────────────────────── */
@@ -140,6 +141,13 @@ body {
 .connection-label {
   color: var(--text-secondary);
   font-weight: 500;
+}
+
+.connection-metrics {
+  display: flex;
+  gap: 10px;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
 }
 
 /* ── Connection Bar ──────────────────────────── */
@@ -519,6 +527,42 @@ body {
   border-color: var(--border-accent);
 }
 
+/* ── Toast ───────────────────────────────────── */
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+}
+
+.toast {
+  min-width: 260px;
+  max-width: min(420px, calc(100vw - 32px));
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-primary);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-md);
+  animation: slide-in-right var(--transition-base);
+  font-size: var(--font-sm);
+}
+
+.toast.toast-error {
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.toast.toast-warning {
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.toast.toast-success {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
 /* ── Activity Panel ──────────────────────────── */
 .activity-panel {
   display: flex;
@@ -746,14 +790,20 @@ body {
 
 /* ── Responsive ──────────────────────────────── */
 @media (max-width: 900px) {
+  .app-layout {
+    min-height: 100dvh;
+  }
+
   .main-content {
     grid-template-columns: 1fr;
     padding: 12px 12px 20px;
+    padding-bottom: calc(20px + env(safe-area-inset-bottom));
   }
 
   .chat-panel {
     margin-right: 0;
     margin-bottom: 12px;
+    max-height: calc(100dvh - 210px);
   }
 
   .connection-form {
@@ -766,6 +816,16 @@ body {
 
   .app-header {
     padding: 12px 16px;
+    align-items: flex-start;
+    gap: 8px;
+    flex-direction: column;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
   }
 
   .connection-bar {
@@ -773,10 +833,29 @@ body {
   }
 
   .messages-area {
-    max-height: 50vh;
+    max-height: none;
+    min-height: 200px;
   }
 
   .activity-feed {
     max-height: 40vh;
+  }
+
+  .chat-input-form {
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-secondary);
+    padding-bottom: calc(8px + env(safe-area-inset-bottom));
+    z-index: 2;
+  }
+
+  .toast-container {
+    top: 12px;
+    right: 12px;
+    left: 12px;
+  }
+
+  .toast {
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
Frontend bugs and UX gaps were fixed in one batch to improve reliability for chat/live voice usage.

## Changes
- persist gateway URL in localStorage and restore on load
- add health metrics UI (Ping, Reconnects) in header
- add /ping latency checks on an interval while connected
- add unified toast notifications for connect/error/warning states
- add request in-flight lock to prevent duplicate chat submissions
- add message list pruning to avoid unbounded DOM growth
- improve textarea layout and autosize behavior
- harden WebSocket lifecycle state transitions and manual disconnect messaging
- switch mic capture path to AudioWorklet when supported, fallback to ScriptProcessor otherwise
- improve mobile layout: 100dvh, sticky input area, safe-area handling

## Validation
- 
ode --check web/app.js passed