### PR TITLE
fix: improve agent activity visibility with request progress and status detail

### DIFF
--- a/live_gateway/test_health_endpoints.py
+++ b/live_gateway/test_health_endpoints.py
@@ -53,6 +53,19 @@ class HealthEndpointTests(unittest.TestCase):
         self.assertIn("request.headers.items()", source)
         self.assertIn("key.lower()", source)
 
+    def test_query_agent_emits_request_id_and_progress(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn('"request_id": request_id', source)
+        self.assertIn('"progress": {', source)
+        self.assertIn('"total_tool_calls": total_tool_calls', source)
+        self.assertIn('"completed_tool_calls": completed_tool_calls', source)
+
+    def test_error_detail_helper_exists(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn("def _extract_error_detail", source)
+        self.assertIn('for field in direct_fields', source)
+        self.assertIn('for container_key in ("error", "result", "response")', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -103,6 +103,11 @@
           <div class="panel-header">
             <i data-lucide="activity"></i>
             <span>Agent Activity</span>
+            <div class="activity-meta" id="activity-meta">
+              <span id="activity-request-id">Request: -</span>
+              <span id="activity-progress">Progress: 0/0</span>
+              <span id="activity-step">Step: Idle</span>
+            </div>
             <button class="btn-icon" id="clear-activity" title="Clear">
               <i data-lucide="x"></i>
             </button>

--- a/web/style.css
+++ b/web/style.css
@@ -326,6 +326,15 @@ body {
   margin-left: auto;
 }
 
+.activity-meta {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
 /* ── Chat Panel ──────────────────────────────── */
 .chat-panel {
   display: flex;
@@ -706,6 +715,13 @@ body {
   margin-top: 2px;
 }
 
+.activity-detail {
+  margin-top: 4px;
+  font-size: var(--font-xs);
+  color: #fca5a5;
+  word-break: break-word;
+}
+
 .activity-status {
   display: flex;
   align-items: center;
@@ -826,6 +842,15 @@ body {
     justify-content: space-between;
     gap: 8px;
     flex-wrap: wrap;
+  }
+
+  .activity-meta {
+    order: 3;
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 6px 10px;
   }
 
   .connection-bar {


### PR DESCRIPTION
## Summary
Improve real-time agent state visibility so users can understand what is in progress and what has completed.

## Changes
- add request-level metadata to gateway activity events (equest_id, tool progress counters)
- include error detail extraction for failed tool results
- show activity header metadata in frontend: request id, progress, current step
- render failure detail text in Activity items for quicker troubleshooting
- keep activity header state synced across thinking/tool/done/response/error/disconnect transitions
- add tests to validate gateway emits request/progress metadata and error detail helper exists

## Test Results
- 
ode --check web/app.js : passed
- python -m unittest live_gateway.test_health_endpoints -v : passed
- python -m unittest test_connection_env_wiring live_gateway.test_health_endpoints -v : passed