### PR TITLE
fix: improve live voice UX with agent-first greeting and speaking orb

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -78,6 +78,10 @@
             <button id="stop-audio" class="btn btn-audio btn-audio-stop" disabled title="Stop Audio">
               <i data-lucide="mic-off"></i>
             </button>
+            <div class="voice-orb voice-orb-idle" id="voice-orb" aria-label="Agent voice status">
+              <div class="voice-orb-core"></div>
+              <div class="voice-orb-ring"></div>
+            </div>
             <div class="audio-level-container" id="audio-level-container">
               <div class="audio-level-bar" id="audio-level-bar"></div>
             </div>

--- a/web/style.css
+++ b/web/style.css
@@ -473,6 +473,51 @@ body {
   margin-top: 8px;
 }
 
+.voice-orb {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+}
+
+.voice-orb-core,
+.voice-orb-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+}
+
+.voice-orb-core {
+  width: 12px;
+  height: 12px;
+  margin: auto;
+  background: var(--text-muted);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.voice-orb-ring {
+  border: 2px solid rgba(100, 116, 139, 0.35);
+  transform: scale(0.9);
+  transition: border-color var(--transition-fast);
+}
+
+.voice-orb.voice-orb-listening .voice-orb-core {
+  background: var(--accent-green);
+}
+
+.voice-orb.voice-orb-listening .voice-orb-ring {
+  border-color: rgba(34, 197, 94, 0.55);
+}
+
+.voice-orb.voice-orb-speaking .voice-orb-core {
+  background: var(--accent-teal);
+}
+
+.voice-orb.voice-orb-speaking .voice-orb-ring {
+  border-color: rgba(20, 184, 166, 0.75);
+  animation: voice-ring-wave 1s ease-out infinite;
+}
+
 .audio-level-container {
   flex: 1;
   height: 6px;
@@ -801,6 +846,17 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes voice-ring-wave {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(1.45);
+    opacity: 0.15;
   }
 }
 


### PR DESCRIPTION
## Summary
Update live voice UX so sessions begin with an agent greeting, then transition to user response mode. Add a clear speaking orb animation while the agent is talking.

## Changes
- add voice orb UI element in the audio control bar
- add orb state styles (idle, listening, speaking) with wave animation while speaking
- change live voice start flow to agent-first greeting
- gate microphone audio chunk upload until greeting phase completes
- add greeting unlock timeout fallback in case greeting audio is delayed
- switch to listening mode automatically after greeting playback ends
- show status/system guidance messages for the greeting phase

## Validation
- 
ode --check web/app.js passed