### PR TITLE
Gmail: SIDfmメール検出を sender OR subject に変更

### DIFF
--- a/agent/tools/gmail_tools.py
+++ b/agent/tools/gmail_tools.py
@@ -162,8 +162,8 @@ def get_sidfm_emails(max_results: int = 10) -> dict[str, Any]:
     try:
         service = _get_gmail_service()
 
-        # SIDfmからの未読メールを検索
-        query = f"from:{sidfm_sender} is:unread"
+        # SIDfmからの未読メールを検索（送信者 or 件名タグ）
+        query = f'(from:{sidfm_sender} OR subject:"[SIDfm]") is:unread'
 
         results = service.users().messages().list(
             userId="me",


### PR DESCRIPTION
## 概要
- `get_sidfm_emails` の検索条件を `(from:... OR subject:"[SIDfm]") is:unread` に変更
- 送信者条件のみだった検出を、件名タグでも拾えるように改善
- クエリ検証テストを追加・更新

## 変更ファイル
- agent/tools/gmail_tools.py
- test_tool_edge_cases.py

## テスト
- `python -m unittest test_tool_edge_cases.py -v`
  - 6 tests passed
