### PR TITLE
fix: refine voice orb line style and add exit controls for overlay

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -128,10 +128,15 @@
     <div class="voice-session-overlay" id="voice-session-overlay" aria-live="polite">
       <div class="voice-session-content">
         <div class="voice-orb-large" id="voice-orb-large">
-          <div class="voice-orb-large-shape" id="voice-orb-large-shape"></div>
-          <div class="voice-orb-large-core"></div>
+          <svg class="voice-orb-large-svg" viewBox="-120 -120 240 240" aria-hidden="true">
+            <path id="voice-orb-large-path" class="voice-orb-large-path"></path>
+          </svg>
         </div>
         <div class="voice-session-label" id="voice-session-label">Agent Greeting...</div>
+        <button id="voice-session-close" class="btn btn-outline voice-session-close" type="button">
+          <i data-lucide="x-circle"></i>
+          <span>対話を終了</span>
+        </button>
       </div>
     </div>
     <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>

--- a/web/style.css
+++ b/web/style.css
@@ -527,7 +527,7 @@ body {
   background: rgba(4, 8, 20, 0.5);
   backdrop-filter: blur(4px);
   z-index: 900;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .voice-session-overlay.active {
@@ -547,28 +547,21 @@ body {
   height: 240px;
 }
 
-.voice-orb-large-shape {
+.voice-orb-large-svg {
   position: absolute;
   inset: 0;
-  border-radius: 50%;
-  background: transparent;
-  border: 2px solid rgba(255, 255, 255, 0.92);
-  box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.18),
-    0 0 30px rgba(255, 255, 255, 0.22);
-  transform-origin: center;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
 }
 
-.voice-orb-large-core {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.45);
+.voice-orb-large-path {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.95);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.24));
 }
 
 .voice-session-label {
@@ -576,6 +569,10 @@ body {
   font-weight: 600;
   color: var(--text-primary);
   text-shadow: 0 1px 8px rgba(0, 0, 0, 0.45);
+}
+
+.voice-session-close {
+  pointer-events: auto;
 }
 
 .audio-level-container {
@@ -1003,10 +1000,5 @@ body {
   .voice-orb-large {
     width: 180px;
     height: 180px;
-  }
-
-  .voice-orb-large-core {
-    width: 8px;
-    height: 8px;
   }
 }


### PR DESCRIPTION
## Summary
Improve live voice overlay usability and visual consistency.

## Changes
- remove center dot from the large orb
- switch large orb to a continuous single white stroke (SVG path) instead of segmented clipped ring
- smooth jagged-edge animation while keeping a connected circle stroke
- reduce false greeting fallback by treating incoming live_text as greeting-received signal as well
- extend greeting fallback window (20s) for slow first-audio scenarios
- add explicit exit controls for overlay:
  - new 対話を終了 button
  - Escape key closes voice session

## Validation
- node --check web/app.js passed