### PR TITLE
Add event-driven Gmail push trigger for SIDfm processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ SIDfm の脆弱性通知メールを取り込み、SBOM と突合して担当者
 - 担当者マッピングで通知先特定
 - Google Chat へカード通知
 - BigQuery へ対応履歴保存
+- Gmail 受信トリガー実行（Pub/Sub + Cloud Functions）
 - 定期スキャン（Cloud Scheduler + Cloud Functions）
 
 ## 構成
 - `agent/`: Agent Engine 本体（ツール実装含む）
 - `scheduler/`: 定期実行エントリーポイント
+- `gmail_trigger/`: Gmail Push 通知トリガー
 - `live_gateway/`: リアルタイム対話ゲートウェイ（任意）
 - `web/`: Web UI（任意）
 - `setup_cloud.sh`: 初期セットアップ
@@ -50,7 +52,7 @@ echo -n "$OAUTH_TOKEN" | gcloud secrets create vuln-agent-gmail-oauth-token \
 bash setup_cloud.sh
 ```
 
-このスクリプトで API 有効化、必要 Secret 作成、BigQuery テーブル作成、Agent/Scheduler などのデプロイまで実行します。
+このスクリプトで API 有効化、必要 Secret 作成、BigQuery テーブル作成、Agent/Scheduler/Gmail Trigger などのデプロイまで実行します。
 
 ## BigQuery 利用時の必須設定
 `SBOM_DATA_BACKEND=bigquery` の場合、以下 Secret が必要です。
@@ -106,6 +108,7 @@ gcloud builds submit --config cloudbuild.yaml
 gcloud logging read 'resource.type="aiplatform.googleapis.com/ReasoningEngine"' --limit=20
 gcloud run services logs read vuln-agent-live-gateway --region=asia-northeast1 --limit=20
 gcloud functions logs read vuln-agent-scheduler --region=asia-northeast1 --limit=20
+gcloud functions logs read vuln-agent-gmail-trigger --region=asia-northeast1 --limit=20
 ```
 
 ## ツール一覧（Agent）
@@ -130,3 +133,4 @@ gcloud functions logs read vuln-agent-scheduler --region=asia-northeast1 --limit
 - `docs/SETUP_CHAT.md`
 - `docs/SETUP_A2A.md`
 - `docs/SETUP_SCHEDULER.md`
+- `docs/SETUP_GMAIL_TRIGGER.md`

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,6 +37,7 @@ steps:
         DEPLOY_AGENT=false
         DEPLOY_GATEWAY=false
         DEPLOY_SCHEDULER=false
+        DEPLOY_GMAIL_TRIGGER=false
         DEPLOY_WEB=false
 
         full_deploy_raw="${_FORCE_FULL_DEPLOY}"
@@ -56,12 +57,14 @@ steps:
           DEPLOY_AGENT=true
           DEPLOY_GATEWAY=true
           DEPLOY_SCHEDULER=true
+          DEPLOY_GMAIL_TRIGGER=true
           DEPLOY_WEB=true
           echo "強制フルデプロイを有効化しました。"
         elif [ -z "$$changed_files_raw" ]; then
           DEPLOY_AGENT=true
           DEPLOY_GATEWAY=true
           DEPLOY_SCHEDULER=true
+          DEPLOY_GMAIL_TRIGGER=true
           DEPLOY_WEB=true
           echo "変更ファイルを判定できないため安全側で全デプロイを実行します。"
         else
@@ -77,6 +80,9 @@ steps:
                 ;;
               scheduler/*)
                 DEPLOY_SCHEDULER=true
+                ;;
+              gmail_trigger/*)
+                DEPLOY_GMAIL_TRIGGER=true
                 ;;
               web/*)
                 DEPLOY_WEB=true
@@ -94,6 +100,7 @@ steps:
             DEPLOY_AGENT=true
             DEPLOY_GATEWAY=true
             DEPLOY_SCHEDULER=true
+            DEPLOY_GMAIL_TRIGGER=true
             DEPLOY_WEB=true
             echo "共通または未知パスの変更を検知したため全デプロイを実行します。"
           fi
@@ -103,6 +110,7 @@ steps:
         DEPLOY_AGENT=$$DEPLOY_AGENT
         DEPLOY_GATEWAY=$$DEPLOY_GATEWAY
         DEPLOY_SCHEDULER=$$DEPLOY_SCHEDULER
+        DEPLOY_GMAIL_TRIGGER=$$DEPLOY_GMAIL_TRIGGER
         DEPLOY_WEB=$$DEPLOY_WEB
         EOF
 
@@ -316,10 +324,10 @@ steps:
           source /workspace/.deploy_flags
         fi
         if [ "${DEPLOY_SCHEDULER:-true}" != "true" ]; then
-          echo "[Step 4/5] Scheduler が対象外のためデプロイをスキップします"
+          echo "[Step 4/6] Scheduler が対象外のためデプロイをスキップします"
           exit 0
         fi
-        echo "[Step 4/5] Scheduler デプロイ条件を確認します"
+        echo "[Step 4/6] Scheduler デプロイ条件を確認します"
         # --set-secrets で参照するため Secret の存在のみ確認する。
         # Secret の値 (AGENT_RESOURCE_NAME) は Cloud Functions がランタイムで
         # 読み取るため、デプロイ時に Agent Engine の疎通確認は行わない。
@@ -328,7 +336,7 @@ steps:
           echo "初回セットアップ (setup_cloud.sh) を先に実行してください。"
           exit 1
         fi
-        echo "[Step 4/5] Scheduler を Cloud Functions にデプロイします"
+        echo "[Step 4/6] Scheduler を Cloud Functions にデプロイします"
         gcloud functions deploy vuln-agent-scheduler \
           --gen2 \
           --runtime=python312 \
@@ -347,7 +355,70 @@ steps:
       - deploy-agent
 
   # =========================================
-  # Step 5: Web UI を Cloud Storage にデプロイ
+  # Step 5: Gmail Trigger を Cloud Functions にデプロイ
+  # =========================================
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: deploy-gmail-trigger
+    entrypoint: bash
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+        if [ -f /workspace/.deploy_flags ]; then
+          source /workspace/.deploy_flags
+        fi
+        if [ "${DEPLOY_GMAIL_TRIGGER:-true}" != "true" ]; then
+          echo "[Step 5/6] Gmail Trigger が対象外のためデプロイをスキップします"
+          exit 0
+        fi
+        echo "[Step 5/6] Gmail Trigger デプロイ条件を確認します"
+        if ! gcloud secrets describe vuln-agent-resource-name >/dev/null 2>&1; then
+          echo "エラー: vuln-agent-resource-name シークレットが存在しません。"
+          echo "初回セットアップ (setup_cloud.sh) を先に実行してください。"
+          exit 1
+        fi
+        if ! gcloud pubsub topics describe vuln-agent-gmail-events >/dev/null 2>&1; then
+          gcloud pubsub topics create vuln-agent-gmail-events >/dev/null
+        fi
+        gcloud pubsub topics add-iam-policy-binding vuln-agent-gmail-events \
+          --member="serviceAccount:gmail-api-push@system.gserviceaccount.com" \
+          --role="roles/pubsub.publisher" --quiet >/dev/null 2>&1 || true
+        echo "[Step 5/6] Gmail Push Trigger を Cloud Functions にデプロイします"
+        gcloud functions deploy vuln-agent-gmail-trigger \
+          --gen2 \
+          --runtime=python312 \
+          --region=${_REGION} \
+          --source=gmail_trigger \
+          --entry-point=handle_gmail_push \
+          --trigger-topic=vuln-agent-gmail-events \
+          --service-account=vuln-agent-sa@${PROJECT_ID}.iam.gserviceaccount.com \
+          --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${_REGION},GMAIL_WATCH_TOPIC=projects/${PROJECT_ID}/topics/vuln-agent-gmail-events" \
+          --remove-env-vars="AGENT_RESOURCE_NAME,GMAIL_OAUTH_TOKEN,GMAIL_USER_EMAIL,SIDFM_SENDER_EMAIL" \
+          --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest" \
+          --memory=512MB \
+          --timeout=540s \
+          --quiet
+
+        echo "[Step 5/6] Gmail watch refresh Function をデプロイします"
+        gcloud functions deploy vuln-agent-gmail-watch-refresh \
+          --gen2 \
+          --runtime=python312 \
+          --region=${_REGION} \
+          --source=gmail_trigger \
+          --entry-point=refresh_gmail_watch \
+          --trigger-http \
+          --no-allow-unauthenticated \
+          --service-account=vuln-agent-sa@${PROJECT_ID}.iam.gserviceaccount.com \
+          --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${_REGION},GMAIL_WATCH_TOPIC=projects/${PROJECT_ID}/topics/vuln-agent-gmail-events" \
+          --remove-env-vars="GMAIL_OAUTH_TOKEN,GMAIL_USER_EMAIL,SIDFM_SENDER_EMAIL" \
+          --memory=256MB \
+          --timeout=120s \
+          --quiet
+    waitFor:
+      - deploy-agent
+
+  # =========================================
+  # Step 6: Web UI を Cloud Storage にデプロイ
   # =========================================
   - name: "gcr.io/cloud-builders/gsutil"
     id: deploy-web-ui
@@ -360,10 +431,10 @@ steps:
           source /workspace/.deploy_flags
         fi
         if [ "${DEPLOY_WEB:-true}" != "true" ]; then
-          echo "[Step 5/5] Web UI が対象外のためデプロイをスキップします"
+          echo "[Step 6/6] Web UI が対象外のためデプロイをスキップします"
           exit 0
         fi
-        echo "[Step 5/5] Web UI を Cloud Storage にデプロイします"
+        echo "[Step 6/6] Web UI を Cloud Storage にデプロイします"
         BUCKET=gs://${PROJECT_ID}-vuln-agent-ui
         gsutil mb -p ${PROJECT_ID} -l ${_REGION} $$BUCKET 2>/dev/null || true
         gsutil web set -m index.html -e index.html $$BUCKET

--- a/docs/SETUP_GMAIL_TRIGGER.md
+++ b/docs/SETUP_GMAIL_TRIGGER.md
@@ -1,0 +1,33 @@
+# Gmail受信トリガー セットアップガイド
+
+`setup_cloud.sh` 実行時に、以下が自動構築されます。
+
+- Pub/Sub topic: `vuln-agent-gmail-events`
+- Cloud Functions:
+  - `vuln-agent-gmail-trigger`（Pub/Sub受信）
+  - `vuln-agent-gmail-watch-refresh`（watch更新用HTTP）
+- Cloud Scheduler job: `vuln-agent-gmail-watch-renew`（6時間毎）
+
+## 動作概要
+
+1. Gmail Push 通知が Pub/Sub に届く  
+2. `vuln-agent-gmail-trigger` が起動  
+3. Gmail で以下クエリの未読有無を軽量チェック  
+   `(from:<SIDFM_SENDER_EMAIL> OR subject:"[SIDfm]") is:unread newer_than:7d`
+4. 一致があれば Agent Engine を実行  
+
+## 手動確認コマンド
+
+```bash
+gcloud pubsub topics describe vuln-agent-gmail-events
+gcloud functions describe vuln-agent-gmail-trigger --region=asia-northeast1
+gcloud functions describe vuln-agent-gmail-watch-refresh --region=asia-northeast1
+gcloud scheduler jobs describe vuln-agent-gmail-watch-renew --location=asia-northeast1
+```
+
+## watch更新を手動実行
+
+```bash
+gcloud scheduler jobs run vuln-agent-gmail-watch-renew --location=asia-northeast1
+```
+

--- a/gmail_trigger/main.py
+++ b/gmail_trigger/main.py
@@ -1,0 +1,262 @@
+"""
+Gmail Push Trigger for vulnerability scan execution.
+
+Flow:
+  Pub/Sub (Gmail push) -> Cloud Function -> Gmail lightweight filter -> Agent Engine
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import datetime as dt
+import json
+import logging
+import os
+from typing import Any
+
+import functions_framework
+import vertexai
+from googleapiclient.discovery import build
+
+logger = logging.getLogger(__name__)
+
+GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.modify"
+DEFAULT_SIDFM_SENDER = "noreply@sidfm.com"
+DEFAULT_SUBJECT_TAG = "[SIDfm]"
+DEFAULT_NEWER_THAN = "7d"
+DEFAULT_TOPIC = "vuln-agent-gmail-events"
+
+_secret_client = None
+_gmail_service = None
+
+
+def _get_secret_client():
+    global _secret_client
+    if _secret_client is None:
+        from google.cloud import secretmanager
+
+        _secret_client = secretmanager.SecretManagerServiceClient()
+    return _secret_client
+
+
+def _get_project_id() -> str:
+    return (
+        os.environ.get("GCP_PROJECT_ID")
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("GCLOUD_PROJECT")
+        or ""
+    )
+
+
+def _get_config(env_name: str, secret_name: str, default: str = "") -> str:
+    value = (os.environ.get(env_name) or "").strip()
+    if value:
+        return value
+
+    project_id = _get_project_id()
+    if not project_id:
+        return default
+
+    try:
+        client = _get_secret_client()
+        name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        secret_value = response.payload.data.decode("utf-8").strip()
+        return secret_value or default
+    except Exception:
+        return default
+
+
+def _get_gmail_service():
+    global _gmail_service
+    if _gmail_service is not None:
+        return _gmail_service
+
+    oauth_token = _get_config("GMAIL_OAUTH_TOKEN", "vuln-agent-gmail-oauth-token", "")
+    gmail_user = _get_config("GMAIL_USER_EMAIL", "vuln-agent-gmail-user-email", "")
+
+    credentials = None
+
+    if oauth_token:
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2.credentials import Credentials
+
+            token_json = base64.b64decode(oauth_token).decode("utf-8")
+            token_data = json.loads(token_json)
+
+            credentials = Credentials(
+                token=token_data.get("token"),
+                refresh_token=token_data.get("refresh_token"),
+                token_uri=token_data.get("token_uri", "https://oauth2.googleapis.com/token"),
+                client_id=token_data.get("client_id"),
+                client_secret=token_data.get("client_secret"),
+                scopes=token_data.get("scopes", [GMAIL_SCOPE]),
+            )
+            if credentials.refresh_token:
+                credentials.refresh(Request())
+                logger.info("OAuth token refreshed for Gmail trigger")
+        except Exception as exc:
+            logger.error("OAuth token error: %s", exc)
+            credentials = None
+
+    if not credentials and gmail_user:
+        try:
+            from google.oauth2 import service_account
+
+            sa_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            if sa_path and os.path.exists(sa_path):
+                credentials = service_account.Credentials.from_service_account_file(
+                    sa_path,
+                    scopes=[GMAIL_SCOPE],
+                    subject=gmail_user,
+                )
+        except Exception as exc:
+            logger.error("Domain delegation auth error: %s", exc)
+            credentials = None
+
+    if not credentials:
+        from google.auth import default
+
+        credentials, _ = default(scopes=[GMAIL_SCOPE])
+
+    _gmail_service = build("gmail", "v1", credentials=credentials)
+    return _gmail_service
+
+
+def _build_sidfm_query(sender: str, subject_tag: str, newer_than: str) -> str:
+    safe_subject = (subject_tag or DEFAULT_SUBJECT_TAG).replace('"', "")
+    safe_sender = sender or DEFAULT_SIDFM_SENDER
+    safe_newer_than = newer_than or DEFAULT_NEWER_THAN
+    return f'(from:{safe_sender} OR subject:"{safe_subject}") is:unread newer_than:{safe_newer_than}'
+
+
+def _parse_pubsub_payload(cloud_event: Any) -> dict[str, Any]:
+    raw = ""
+    try:
+        data = cloud_event.get("data") if isinstance(cloud_event, dict) else getattr(cloud_event, "data", {})
+        if isinstance(data, dict):
+            raw = ((data.get("message") or {}).get("data") or "").strip()
+        if not raw:
+            return {}
+        decoded = base64.b64decode(raw).decode("utf-8")
+        return json.loads(decoded)
+    except Exception:
+        return {}
+
+
+def _has_matching_unread_email(service, query: str, max_results: int = 5) -> bool:
+    result = service.users().messages().list(
+        userId="me",
+        q=query,
+        maxResults=max_results,
+    ).execute()
+    return bool(result.get("messages", []))
+
+
+def _run_agent_scan(reason: str) -> dict[str, Any]:
+    project_id = _get_project_id()
+    location = os.environ.get("GCP_LOCATION", "asia-northeast1")
+    agent_name = (
+        (os.environ.get("AGENT_RESOURCE_NAME") or "").strip()
+        or _get_config("AGENT_RESOURCE_NAME", "vuln-agent-resource-name", "")
+    )
+    if not agent_name:
+        raise RuntimeError("AGENT_RESOURCE_NAME is required")
+
+    vertexai.init(project=project_id, location=location)
+    from vertexai import Client
+
+    client = Client(project=project_id, location=location)
+    app = client.agent_engines.get(name=agent_name)
+
+    prompt = f"""
+    Gmail Push 通知を受信しました（理由: {reason}）。
+    新しい SIDfm 脆弱性通知メールを確認し、未処理があれば処理してください:
+    1. SBOMと照合して影響システムを特定
+    2. 優先度を判定
+    3. 担当者へ通知
+    4. 対象メールを既読化
+    """
+
+    results: list[str] = []
+
+    async def execute_scan():
+        async for event in app.async_stream_query(
+            user_id="gmail-push-trigger",
+            message=prompt,
+        ):
+            if hasattr(event, "content"):
+                for part in event.content.get("parts", []):
+                    text = part.get("text")
+                    if text:
+                        results.append(text)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(execute_scan())
+    finally:
+        loop.close()
+
+    summary = "\n".join(results)
+    return {"status": "success", "summary": summary}
+
+
+@functions_framework.cloud_event
+def handle_gmail_push(cloud_event):
+    payload = _parse_pubsub_payload(cloud_event)
+    history_id = payload.get("historyId", "")
+    email = payload.get("emailAddress", "")
+    logger.info("Received Gmail push event: email=%s historyId=%s", email, history_id)
+
+    sender = _get_config("SIDFM_SENDER_EMAIL", "vuln-agent-sidfm-sender", DEFAULT_SIDFM_SENDER)
+    subject_tag = (os.environ.get("SIDFM_SUBJECT_TAG") or DEFAULT_SUBJECT_TAG).strip()
+    newer_than = (os.environ.get("SIDFM_QUERY_NEWER_THAN") or DEFAULT_NEWER_THAN).strip()
+    query = _build_sidfm_query(sender, subject_tag, newer_than)
+
+    try:
+        service = _get_gmail_service()
+        if not _has_matching_unread_email(service, query):
+            logger.info("No SIDfm unread email matched query, skipping agent execution. query=%s", query)
+            return {"status": "skipped", "reason": "no_matching_email"}
+
+        result = _run_agent_scan(reason=f"historyId={history_id}")
+        logger.info("Agent execution completed: %s", result.get("status"))
+        return result
+    except Exception as exc:
+        logger.exception("Failed to handle Gmail push: %s", exc)
+        return {"status": "error", "message": str(exc)}
+
+
+@functions_framework.http
+def refresh_gmail_watch(request):
+    _ = request
+    service = _get_gmail_service()
+    project_id = _get_project_id()
+    topic = (
+        os.environ.get("GMAIL_WATCH_TOPIC")
+        or f"projects/{project_id}/topics/{DEFAULT_TOPIC}"
+    )
+    label_ids = [item.strip() for item in (os.environ.get("GMAIL_WATCH_LABEL_IDS") or "INBOX").split(",") if item.strip()]
+    body = {
+        "topicName": topic,
+        "labelFilterAction": "include",
+        "labelIds": label_ids,
+    }
+
+    response = service.users().watch(userId="me", body=body).execute()
+    expiration = response.get("expiration")
+    expiration_iso = ""
+    if expiration:
+        expiration_dt = dt.datetime.fromtimestamp(int(expiration) / 1000, tz=dt.timezone.utc)
+        expiration_iso = expiration_dt.isoformat()
+
+    payload = {
+        "status": "success",
+        "topic": topic,
+        "historyId": response.get("historyId"),
+        "expiration": expiration,
+        "expiration_iso": expiration_iso,
+    }
+    return json.dumps(payload, ensure_ascii=False), 200, {"Content-Type": "application/json"}

--- a/gmail_trigger/requirements.txt
+++ b/gmail_trigger/requirements.txt
@@ -1,0 +1,5 @@
+functions-framework>=3.0.0
+google-cloud-aiplatform[agent_engines]>=1.112.0
+google-api-python-client>=2.120.0
+google-auth>=2.20.0
+google-cloud-secret-manager>=2.20.0

--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -66,6 +66,7 @@ step "1/8: API を有効化しています..."
 APIS=(
   aiplatform.googleapis.com
   gmail.googleapis.com
+  pubsub.googleapis.com
   sheets.googleapis.com
   chat.googleapis.com
   bigquery.googleapis.com
@@ -416,15 +417,15 @@ fi
 rm -f agent/.env
 
 # ====================================================
-# 7. Live Gateway / Scheduler のデプロイ
+# 7. Live Gateway / Scheduler / Gmail Trigger のデプロイ
 # ====================================================
-step "7/8: Live Gateway と Scheduler をデプロイしています..."
+step "7/8: Live Gateway / Scheduler / Gmail Trigger をデプロイしています..."
 
 if [[ -n "$AGENT_RESOURCE_NAME" ]]; then
   info "Agent Engine の存在を確認しています..."
   if ! _wait_engine_ready "$AGENT_RESOURCE_NAME"; then
     err "Agent Resource Name が無効です（ReasoningEngine が存在しません）: ${AGENT_RESOURCE_NAME}"
-    err "Live Gateway / Scheduler のデプロイを中止します。"
+    err "Live Gateway / Scheduler / Gmail Trigger のデプロイを中止します。"
     exit 1
   fi
 
@@ -498,8 +499,120 @@ if [[ -n "$AGENT_RESOURCE_NAME" ]]; then
     err "Cloud Scheduler ジョブの作成に失敗しました"
     exit 1
   fi
+
+  # --- Gmail Push Trigger (Pub/Sub + Cloud Functions) ---
+  GMAIL_TOPIC="vuln-agent-gmail-events"
+  GMAIL_TRIGGER_FUNCTION="vuln-agent-gmail-trigger"
+  GMAIL_WATCH_REFRESH_FUNCTION="vuln-agent-gmail-watch-refresh"
+  GMAIL_WATCH_RENEW_JOB="vuln-agent-gmail-watch-renew"
+  GMAIL_WATCH_TOPIC_FULL="projects/${PROJECT_ID}/topics/${GMAIL_TOPIC}"
+
+  if gcloud pubsub topics describe "$GMAIL_TOPIC" --project="$PROJECT_ID" &>/dev/null; then
+    info "Pub/Sub topic 既存: ${GMAIL_TOPIC}"
+  elif gcloud pubsub topics create "$GMAIL_TOPIC" --project="$PROJECT_ID"; then
+    info "Pub/Sub topic 作成: ${GMAIL_TOPIC}"
+  else
+    err "Pub/Sub topic の作成に失敗しました: ${GMAIL_TOPIC}"
+    exit 1
+  fi
+
+  gcloud pubsub topics add-iam-policy-binding "$GMAIL_TOPIC" \
+    --project="$PROJECT_ID" \
+    --member="serviceAccount:gmail-api-push@system.gserviceaccount.com" \
+    --role="roles/pubsub.publisher" \
+    --quiet >/dev/null 2>&1 || true
+
+  info "Gmail Push Trigger を Cloud Functions にデプロイ中..."
+  if ! gcloud functions deploy "$GMAIL_TRIGGER_FUNCTION" \
+    --gen2 \
+    --runtime=python312 \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --source=gmail_trigger \
+    --entry-point=handle_gmail_push \
+    --trigger-topic="$GMAIL_TOPIC" \
+    --service-account="$SA_EMAIL" \
+    --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION},GMAIL_WATCH_TOPIC=${GMAIL_WATCH_TOPIC_FULL}" \
+    --remove-env-vars="AGENT_RESOURCE_NAME,GMAIL_OAUTH_TOKEN,GMAIL_USER_EMAIL,SIDFM_SENDER_EMAIL" \
+    --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest" \
+    --memory=512MB \
+    --timeout=540s \
+    --quiet; then
+    err "Gmail Push Trigger のデプロイに失敗しました"
+    exit 1
+  fi
+
+  info "Gmail watch 更新 Function をデプロイ中..."
+  if ! gcloud functions deploy "$GMAIL_WATCH_REFRESH_FUNCTION" \
+    --gen2 \
+    --runtime=python312 \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --source=gmail_trigger \
+    --entry-point=refresh_gmail_watch \
+    --trigger-http \
+    --no-allow-unauthenticated \
+    --service-account="$SA_EMAIL" \
+    --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${REGION},GMAIL_WATCH_TOPIC=${GMAIL_WATCH_TOPIC_FULL}" \
+    --remove-env-vars="GMAIL_OAUTH_TOKEN,GMAIL_USER_EMAIL,SIDFM_SENDER_EMAIL" \
+    --memory=256MB \
+    --timeout=120s \
+    --quiet; then
+    err "Gmail watch 更新 Function のデプロイに失敗しました"
+    exit 1
+  fi
+
+  GMAIL_WATCH_REFRESH_URL=$(gcloud functions describe "$GMAIL_WATCH_REFRESH_FUNCTION" \
+    --region="$REGION" --project="$PROJECT_ID" --format='value(serviceConfig.uri)')
+  info "Gmail watch refresh Function: ${GMAIL_WATCH_REFRESH_URL}"
+
+  gcloud functions add-invoker-policy-binding "$GMAIL_WATCH_REFRESH_FUNCTION" \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --member="serviceAccount:${SA_EMAIL}" >/dev/null 2>&1 || true
+
+  if gcloud scheduler jobs describe "$GMAIL_WATCH_RENEW_JOB" --location="$REGION" --project="$PROJECT_ID" &>/dev/null; then
+    if ! gcloud scheduler jobs update http "$GMAIL_WATCH_RENEW_JOB" \
+      --location="$REGION" \
+      --project="$PROJECT_ID" \
+      --schedule="0 */6 * * *" \
+      --time-zone="Asia/Tokyo" \
+      --uri="$GMAIL_WATCH_REFRESH_URL" \
+      --http-method=POST \
+      --oidc-service-account-email="$SA_EMAIL" \
+      --oidc-token-audience="$GMAIL_WATCH_REFRESH_URL"; then
+      err "Gmail watch 更新 Scheduler ジョブの更新に失敗しました"
+      exit 1
+    fi
+    info "Gmail watch 更新 Scheduler ジョブを更新しました (6時間毎)"
+  elif gcloud scheduler jobs create http "$GMAIL_WATCH_RENEW_JOB" \
+      --location="$REGION" \
+      --project="$PROJECT_ID" \
+      --schedule="0 */6 * * *" \
+      --time-zone="Asia/Tokyo" \
+      --uri="$GMAIL_WATCH_REFRESH_URL" \
+      --http-method=POST \
+      --oidc-service-account-email="$SA_EMAIL" \
+      --oidc-token-audience="$GMAIL_WATCH_REFRESH_URL"; then
+    info "Gmail watch 更新 Scheduler ジョブを作成しました (6時間毎)"
+  else
+    err "Gmail watch 更新 Scheduler ジョブの作成に失敗しました"
+    exit 1
+  fi
+
+  # 初回セットアップ時に watch を即時登録
+  ID_TOKEN=$(gcloud auth print-identity-token --audiences="$GMAIL_WATCH_REFRESH_URL" 2>/dev/null || true)
+  if [[ -n "$ID_TOKEN" ]]; then
+    if curl -sSf -X POST -H "Authorization: Bearer ${ID_TOKEN}" "$GMAIL_WATCH_REFRESH_URL" >/dev/null; then
+      info "Gmail watch を初期登録しました"
+    else
+      warn "Gmail watch 初期登録に失敗しました。手動実行: gcloud scheduler jobs run ${GMAIL_WATCH_RENEW_JOB} --location=${REGION}"
+    fi
+  else
+    warn "ID トークン取得に失敗したため Gmail watch 初期登録をスキップしました"
+  fi
 else
-  warn "Agent Resource Name が不明のため、Live Gateway / Scheduler のデプロイをスキップしました"
+  warn "Agent Resource Name が不明のため、Live Gateway / Scheduler / Gmail Trigger のデプロイをスキップしました"
 fi
 
 # ====================================================
@@ -527,6 +640,8 @@ echo "  ────────────────────────
 echo "  Agent Engine   : ${AGENT_RESOURCE_NAME:-'(手動確認が必要)'}"
 echo "  Live Gateway   : ${GATEWAY_URL:-'(スキップ)'}"
 echo "  Scheduler      : ${FUNCTION_URL:-'(スキップ)'}"
+echo "  Gmail Trigger  : ${GMAIL_TRIGGER_FUNCTION:-'(スキップ)'}"
+echo "  Watch Refresh  : ${GMAIL_WATCH_REFRESH_URL:-'(スキップ)'}"
 echo "  Web UI         : ${WEB_URL}"
 echo ""
 echo "  次のステップ:"

--- a/test_cloudbuild_optimizations.py
+++ b/test_cloudbuild_optimizations.py
@@ -24,10 +24,12 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn("DEPLOY_AGENT=", self.content)
         self.assertIn("DEPLOY_GATEWAY=", self.content)
         self.assertIn("DEPLOY_SCHEDULER=", self.content)
+        self.assertIn("DEPLOY_GMAIL_TRIGGER=", self.content)
         self.assertIn("DEPLOY_WEB=", self.content)
         self.assertIn("agent/*)", self.content)
         self.assertIn("live_gateway/*)", self.content)
         self.assertIn("scheduler/*)", self.content)
+        self.assertIn("gmail_trigger/*)", self.content)
         self.assertIn("web/*)", self.content)
         self.assertIsNone(re.search(r"(?<!\$)\$\{BEFORE_SHA", self.content))
         self.assertIsNone(re.search(r"(?<!\$)\$\{COMMIT_SHA", self.content))
@@ -42,6 +44,7 @@ class CloudBuildOptimizationTests(unittest.TestCase):
     def test_component_steps_have_skip_guards(self):
         self.assertIn('if [ "${DEPLOY_GATEWAY:-true}" != "true" ]; then', self.content)
         self.assertIn('if [ "${DEPLOY_SCHEDULER:-true}" != "true" ]; then', self.content)
+        self.assertIn('if [ "${DEPLOY_GMAIL_TRIGGER:-true}" != "true" ]; then', self.content)
         self.assertIn('if [ "${DEPLOY_WEB:-true}" != "true" ]; then', self.content)
 
 

--- a/test_connection_env_wiring.py
+++ b/test_connection_env_wiring.py
@@ -100,6 +100,9 @@ class ConnectionEnvWiringTests(unittest.TestCase):
     def test_setup_cloud_has_gmail_user_secret(self):
         self.assertIn("vuln-agent-gmail-user-email", self.setup_cloud_source)
         self.assertIn("GMAIL_USER_EMAIL=$(_sm_get vuln-agent-gmail-user-email)", self.setup_cloud_source)
+        self.assertIn("pubsub.googleapis.com", self.setup_cloud_source)
+        self.assertIn("vuln-agent-gmail-trigger", self.setup_cloud_source)
+        self.assertIn("vuln-agent-gmail-watch-refresh", self.setup_cloud_source)
 
 
 if __name__ == "__main__":

--- a/test_gmail_trigger.py
+++ b/test_gmail_trigger.py
@@ -1,0 +1,63 @@
+import base64
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent
+GMAIL_TRIGGER_PATH = ROOT / "gmail_trigger" / "main.py"
+
+
+def _stub_dependencies() -> None:
+    ff = types.ModuleType("functions_framework")
+    ff.cloud_event = lambda fn: fn
+    ff.http = lambda fn: fn
+    sys.modules["functions_framework"] = ff
+
+    vertexai = types.ModuleType("vertexai")
+    vertexai.init = lambda **kwargs: None
+    vertexai.Client = object
+    sys.modules["vertexai"] = vertexai
+
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    discovery.build = lambda *args, **kwargs: object()
+    googleapiclient.discovery = discovery
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class GmailTriggerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _stub_dependencies()
+        cls.gmail_trigger = _load_module("gmail_trigger_test_module", GMAIL_TRIGGER_PATH)
+
+    def test_build_sidfm_query_uses_or_with_sender_and_subject(self):
+        query = self.gmail_trigger._build_sidfm_query("noreply@sidfm.com", "[SIDfm]", "7d")
+        self.assertEqual(
+            query,
+            '(from:noreply@sidfm.com OR subject:"[SIDfm]") is:unread newer_than:7d',
+        )
+
+    def test_parse_pubsub_payload_decodes_message_data(self):
+        payload = {"emailAddress": "user@example.com", "historyId": "12345"}
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+        cloud_event = {"data": {"message": {"data": encoded}}}
+        parsed = self.gmail_trigger._parse_pubsub_payload(cloud_event)
+        self.assertEqual(parsed, payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- Gmail受信イベントでエージェントを実行する event-driven 経路を追加
- 定期実行（Scheduler）は保険として維持
- 受信検知は `(from:... OR subject:"[SIDfm]") is:unread newer_than:7d` で軽量判定

## 変更内容
- 追加: `gmail_trigger/main.py`
  - `handle_gmail_push` (Pub/Sub CloudEvent)
  - `refresh_gmail_watch` (watch更新HTTP)
- 追加: `gmail_trigger/requirements.txt`
- 追加: `docs/SETUP_GMAIL_TRIGGER.md`
- 追加: `test_gmail_trigger.py`
- 更新: `setup_cloud.sh`
  - Pub/Sub topic / Gmail trigger functions / watch更新Schedulerのデプロイ追加
- 更新: `cloudbuild.yaml`
  - `gmail_trigger/*` 変更時のデプロイ判定・デプロイステップ追加
- 更新: `README.md`, `test_connection_env_wiring.py`, `test_cloudbuild_optimizations.py`

## テスト
- `python -m unittest test_tool_edge_cases.py test_connection_env_wiring.py test_cloudbuild_optimizations.py test_gmail_trigger.py -v`
- 17 tests passed
