### PR TITLE
Add Google Chat mention-based conversation webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SIDfm の脆弱性通知メールを取り込み、SBOM と突合して担当者
 - SBOM（BigQuery または Sheets）で影響システム検索
 - 担当者マッピングで通知先特定
 - Google Chat へカード通知
+- Google Chat メンション対話（Chatアプリ経由）
 - BigQuery へ対応履歴保存
 - Gmail 受信トリガー実行（Pub/Sub + Cloud Functions）
 - 定期スキャン（Cloud Scheduler + Cloud Functions）
@@ -15,6 +16,7 @@ SIDfm の脆弱性通知メールを取り込み、SBOM と突合して担当者
 - `agent/`: Agent Engine 本体（ツール実装含む）
 - `scheduler/`: 定期実行エントリーポイント
 - `gmail_trigger/`: Gmail Push 通知トリガー
+- `chat_webhook/`: Google Chat メンション受信Webhook
 - `live_gateway/`: リアルタイム対話ゲートウェイ（任意）
 - `web/`: Web UI（任意）
 - `setup_cloud.sh`: 初期セットアップ
@@ -52,7 +54,7 @@ echo -n "$OAUTH_TOKEN" | gcloud secrets create vuln-agent-gmail-oauth-token \
 bash setup_cloud.sh
 ```
 
-このスクリプトで API 有効化、必要 Secret 作成、BigQuery テーブル作成、Agent/Scheduler/Gmail Trigger などのデプロイまで実行します。
+このスクリプトで API 有効化、必要 Secret 作成、BigQuery テーブル作成、Agent/Scheduler/Gmail Trigger/Chat Webhook などのデプロイまで実行します。
 
 ## BigQuery 利用時の必須設定
 `SBOM_DATA_BACKEND=bigquery` の場合、以下 Secret が必要です。
@@ -109,6 +111,7 @@ gcloud logging read 'resource.type="aiplatform.googleapis.com/ReasoningEngine"' 
 gcloud run services logs read vuln-agent-live-gateway --region=asia-northeast1 --limit=20
 gcloud functions logs read vuln-agent-scheduler --region=asia-northeast1 --limit=20
 gcloud functions logs read vuln-agent-gmail-trigger --region=asia-northeast1 --limit=20
+gcloud functions logs read vuln-agent-chat-webhook --region=asia-northeast1 --limit=20
 ```
 
 ## ツール一覧（Agent）
@@ -131,6 +134,7 @@ gcloud functions logs read vuln-agent-gmail-trigger --region=asia-northeast1 --l
 詳細手順は `docs/` を参照してください。
 - `docs/SETUP_GMAIL.md`
 - `docs/SETUP_CHAT.md`
+- `docs/SETUP_CHAT_INTERACTIVE.md`
 - `docs/SETUP_A2A.md`
 - `docs/SETUP_SCHEDULER.md`
 - `docs/SETUP_GMAIL_TRIGGER.md`

--- a/chat_webhook/main.py
+++ b/chat_webhook/main.py
@@ -1,0 +1,174 @@
+"""
+Google Chat webhook handler for mention-based conversations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from typing import Any
+
+import functions_framework
+import vertexai
+
+logger = logging.getLogger(__name__)
+
+_secret_client = None
+
+
+def _get_secret_client():
+    global _secret_client
+    if _secret_client is None:
+        from google.cloud import secretmanager
+
+        _secret_client = secretmanager.SecretManagerServiceClient()
+    return _secret_client
+
+
+def _get_project_id() -> str:
+    return (
+        os.environ.get("GCP_PROJECT_ID")
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("GCLOUD_PROJECT")
+        or ""
+    )
+
+
+def _get_config(env_name: str, secret_name: str, default: str = "") -> str:
+    value = (os.environ.get(env_name) or "").strip()
+    if value:
+        return value
+
+    project_id = _get_project_id()
+    if not project_id:
+        return default
+
+    try:
+        client = _get_secret_client()
+        name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        secret_value = response.payload.data.decode("utf-8").strip()
+        return secret_value or default
+    except Exception:
+        return default
+
+
+def _clean_chat_text(event: dict[str, Any]) -> str:
+    message = event.get("message") or {}
+    arg_text = (message.get("argumentText") or "").strip()
+    if arg_text:
+        return arg_text
+
+    raw_text = (message.get("text") or "").strip()
+    if not raw_text:
+        return ""
+
+    text = re.sub(r"<users/[^>]+>", "", raw_text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_valid_token(event: dict[str, Any]) -> bool:
+    expected = _get_config(
+        "CHAT_WEBHOOK_VERIFICATION_TOKEN",
+        "vuln-agent-chat-verification-token",
+        "",
+    )
+    if not expected:
+        return True
+    actual = (event.get("token") or "").strip()
+    return actual == expected
+
+
+def _run_agent_query(prompt: str, user_id: str) -> str:
+    project_id = _get_project_id()
+    location = os.environ.get("GCP_LOCATION", "asia-northeast1")
+    agent_name = (
+        (os.environ.get("AGENT_RESOURCE_NAME") or "").strip()
+        or _get_config("AGENT_RESOURCE_NAME", "vuln-agent-resource-name", "")
+    )
+    if not project_id or not agent_name:
+        raise RuntimeError("GCP_PROJECT_ID and AGENT_RESOURCE_NAME are required")
+
+    vertexai.init(project=project_id, location=location)
+    from vertexai import Client
+
+    client = Client(project=project_id, location=location)
+    app = client.agent_engines.get(name=agent_name)
+
+    chunks: list[str] = []
+
+    async def execute_query():
+        async for event in app.async_stream_query(
+            user_id=user_id or "google-chat-user",
+            message=prompt,
+        ):
+            if hasattr(event, "content"):
+                for part in event.content.get("parts", []):
+                    text = part.get("text")
+                    if text:
+                        chunks.append(text)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(execute_query())
+    finally:
+        loop.close()
+
+    result = "\n".join(chunks).strip()
+    if not result:
+        return "回答を生成できませんでした。もう一度お試しください。"
+    return result[:3500]
+
+
+def _thread_payload(event: dict[str, Any], text: str) -> dict[str, Any]:
+    message = event.get("message") or {}
+    thread_name = ((message.get("thread") or {}).get("name") or "").strip()
+    payload: dict[str, Any] = {"text": text}
+    if thread_name:
+        payload["thread"] = {"name": thread_name}
+    return payload
+
+
+@functions_framework.http
+def handle_chat_event(request):
+    try:
+        event = request.get_json(silent=True) or {}
+    except Exception:
+        event = {}
+
+    if not event:
+        return json.dumps({"text": "Invalid request"}), 400, {"Content-Type": "application/json"}
+
+    if not _is_valid_token(event):
+        return json.dumps({"text": "Unauthorized"}), 403, {"Content-Type": "application/json"}
+
+    event_type = event.get("type", "")
+    user = event.get("user") or {}
+    user_name = (user.get("name") or "").replace("users/", "") or "google-chat-user"
+
+    if event_type == "ADDED_TO_SPACE":
+        text = "追加ありがとうございます。@メンションで脆弱性やSBOMの相談ができます。"
+        return json.dumps({"text": text}, ensure_ascii=False), 200, {"Content-Type": "application/json"}
+
+    if event_type != "MESSAGE":
+        return json.dumps({"text": "Unsupported event type"}), 200, {"Content-Type": "application/json"}
+
+    prompt = _clean_chat_text(event)
+    if not prompt:
+        text = "メンションのあとに質問を入れてください。例: `@bot CVE-2026-XXXX の影響を調べて`"
+        return json.dumps(_thread_payload(event, text), ensure_ascii=False), 200, {"Content-Type": "application/json"}
+
+    try:
+        response_text = _run_agent_query(prompt, user_name)
+        return json.dumps(_thread_payload(event, response_text), ensure_ascii=False), 200, {
+            "Content-Type": "application/json"
+        }
+    except Exception as exc:
+        logger.exception("Failed to handle chat event: %s", exc)
+        return json.dumps(
+            _thread_payload(event, f"処理中にエラーが発生しました: {exc}"),
+            ensure_ascii=False,
+        ), 200, {"Content-Type": "application/json"}

--- a/chat_webhook/requirements.txt
+++ b/chat_webhook/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework>=3.0.0
+google-cloud-aiplatform[agent_engines]>=1.112.0
+google-cloud-secret-manager>=2.20.0

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -38,6 +38,7 @@ steps:
         DEPLOY_GATEWAY=false
         DEPLOY_SCHEDULER=false
         DEPLOY_GMAIL_TRIGGER=false
+        DEPLOY_CHAT_WEBHOOK=false
         DEPLOY_WEB=false
 
         full_deploy_raw="${_FORCE_FULL_DEPLOY}"
@@ -58,6 +59,7 @@ steps:
           DEPLOY_GATEWAY=true
           DEPLOY_SCHEDULER=true
           DEPLOY_GMAIL_TRIGGER=true
+          DEPLOY_CHAT_WEBHOOK=true
           DEPLOY_WEB=true
           echo "強制フルデプロイを有効化しました。"
         elif [ -z "$$changed_files_raw" ]; then
@@ -65,6 +67,7 @@ steps:
           DEPLOY_GATEWAY=true
           DEPLOY_SCHEDULER=true
           DEPLOY_GMAIL_TRIGGER=true
+          DEPLOY_CHAT_WEBHOOK=true
           DEPLOY_WEB=true
           echo "変更ファイルを判定できないため安全側で全デプロイを実行します。"
         else
@@ -84,6 +87,9 @@ steps:
               gmail_trigger/*)
                 DEPLOY_GMAIL_TRIGGER=true
                 ;;
+              chat_webhook/*)
+                DEPLOY_CHAT_WEBHOOK=true
+                ;;
               web/*)
                 DEPLOY_WEB=true
                 ;;
@@ -101,6 +107,7 @@ steps:
             DEPLOY_GATEWAY=true
             DEPLOY_SCHEDULER=true
             DEPLOY_GMAIL_TRIGGER=true
+            DEPLOY_CHAT_WEBHOOK=true
             DEPLOY_WEB=true
             echo "共通または未知パスの変更を検知したため全デプロイを実行します。"
           fi
@@ -111,6 +118,7 @@ steps:
         DEPLOY_GATEWAY=$$DEPLOY_GATEWAY
         DEPLOY_SCHEDULER=$$DEPLOY_SCHEDULER
         DEPLOY_GMAIL_TRIGGER=$$DEPLOY_GMAIL_TRIGGER
+        DEPLOY_CHAT_WEBHOOK=$$DEPLOY_CHAT_WEBHOOK
         DEPLOY_WEB=$$DEPLOY_WEB
         EOF
 
@@ -418,7 +426,50 @@ steps:
       - deploy-agent
 
   # =========================================
-  # Step 6: Web UI を Cloud Storage にデプロイ
+  # Step 6: Chat Webhook を Cloud Functions にデプロイ
+  # =========================================
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: deploy-chat-webhook
+    entrypoint: bash
+    args:
+      - "-c"
+      - |
+        set -euo pipefail
+        if [ -f /workspace/.deploy_flags ]; then
+          source /workspace/.deploy_flags
+        fi
+        if [ "${DEPLOY_CHAT_WEBHOOK:-true}" != "true" ]; then
+          echo "[Step 6/7] Chat Webhook が対象外のためデプロイをスキップします"
+          exit 0
+        fi
+        echo "[Step 6/7] Chat Webhook デプロイ条件を確認します"
+        if ! gcloud secrets describe vuln-agent-resource-name >/dev/null 2>&1; then
+          echo "エラー: vuln-agent-resource-name シークレットが存在しません。"
+          echo "初回セットアップ (setup_cloud.sh) を先に実行してください。"
+          exit 1
+        fi
+        chat_verify_token="$(gcloud secrets versions access latest --secret=vuln-agent-chat-verification-token 2>/dev/null || echo '')"
+        echo "[Step 6/7] Chat Webhook を Cloud Functions にデプロイします"
+        gcloud functions deploy vuln-agent-chat-webhook \
+          --gen2 \
+          --runtime=python312 \
+          --region=${_REGION} \
+          --source=chat_webhook \
+          --entry-point=handle_chat_event \
+          --trigger-http \
+          --allow-unauthenticated \
+          --service-account=vuln-agent-sa@${PROJECT_ID}.iam.gserviceaccount.com \
+          --update-env-vars="GCP_PROJECT_ID=${PROJECT_ID},GCP_LOCATION=${_REGION},CHAT_WEBHOOK_VERIFICATION_TOKEN=$$chat_verify_token" \
+          --remove-env-vars="AGENT_RESOURCE_NAME" \
+          --set-secrets="AGENT_RESOURCE_NAME=vuln-agent-resource-name:latest" \
+          --memory=512MB \
+          --timeout=540s \
+          --quiet
+    waitFor:
+      - deploy-agent
+
+  # =========================================
+  # Step 7: Web UI を Cloud Storage にデプロイ
   # =========================================
   - name: "gcr.io/cloud-builders/gsutil"
     id: deploy-web-ui
@@ -431,10 +482,10 @@ steps:
           source /workspace/.deploy_flags
         fi
         if [ "${DEPLOY_WEB:-true}" != "true" ]; then
-          echo "[Step 6/6] Web UI が対象外のためデプロイをスキップします"
+          echo "[Step 7/7] Web UI が対象外のためデプロイをスキップします"
           exit 0
         fi
-        echo "[Step 6/6] Web UI を Cloud Storage にデプロイします"
+        echo "[Step 7/7] Web UI を Cloud Storage にデプロイします"
         BUCKET=gs://${PROJECT_ID}-vuln-agent-ui
         gsutil mb -p ${PROJECT_ID} -l ${_REGION} $$BUCKET 2>/dev/null || true
         gsutil web set -m index.html -e index.html $$BUCKET

--- a/docs/SETUP_CHAT.md
+++ b/docs/SETUP_CHAT.md
@@ -67,7 +67,7 @@ https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat
 
 | 項目 | 設定 |
 |------|------|
-| **アプリのURL** | 空欄のまま（サービスアカウント認証を使用） |
+| **アプリのURL** | `setup_cloud.sh` が出力する `Chat Webhook URL` |
 
 ### 2.5 公開設定
 

--- a/docs/SETUP_CHAT_INTERACTIVE.md
+++ b/docs/SETUP_CHAT_INTERACTIVE.md
@@ -1,0 +1,39 @@
+# Google Chat メンション対話 セットアップガイド
+
+`setup_cloud.sh` 実行後、以下が自動デプロイされます。
+
+- Cloud Functions: `vuln-agent-chat-webhook`
+- URL: スクリプト出力の `Chat Webhook`
+
+## Chat API 側の設定
+
+Google Cloud Console > Chat API > 構成 で以下を設定します。
+
+1. `アプリのURL` に `vuln-agent-chat-webhook` の URL を設定  
+2. `スペースとグループの会話でアプリを有効にする` を ON  
+3. 必要なら `1:1 でのメッセージ受信` を ON  
+
+## 送信例
+
+スペースでアプリをメンションして質問します。
+
+- `@脆弱性管理Bot CVE-2026-xxxx の影響を確認して`
+- `@脆弱性管理Bot log4j の影響システムを教えて`
+
+## 検証トークン（任意）
+
+Webhook検証を有効にする場合は以下シークレットを登録します。
+
+```bash
+echo -n "your-chat-verification-token" | \
+  gcloud secrets versions add vuln-agent-chat-verification-token --data-file=-
+```
+
+> Chat API の設定値と同じトークンを設定してください。
+
+## ログ確認
+
+```bash
+gcloud functions logs read vuln-agent-chat-webhook --region=asia-northeast1 --limit=50
+```
+

--- a/test_chat_webhook.py
+++ b/test_chat_webhook.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent
+CHAT_WEBHOOK_PATH = ROOT / "chat_webhook" / "main.py"
+
+
+def _stub_dependencies() -> None:
+    ff = types.ModuleType("functions_framework")
+    ff.http = lambda fn: fn
+    sys.modules["functions_framework"] = ff
+
+    vertexai = types.ModuleType("vertexai")
+    vertexai.init = lambda **kwargs: None
+    vertexai.Client = object
+    sys.modules["vertexai"] = vertexai
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get_json(self, silent=True):
+        _ = silent
+        return self._payload
+
+
+class ChatWebhookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _stub_dependencies()
+        cls.chat_webhook = _load_module("chat_webhook_test_module", CHAT_WEBHOOK_PATH)
+
+    def test_clean_chat_text_prefers_argument_text(self):
+        text = self.chat_webhook._clean_chat_text(
+            {"message": {"argumentText": "  CVEを調べて  ", "text": "@bot 無視される"}}
+        )
+        self.assertEqual(text, "CVEを調べて")
+
+    def test_clean_chat_text_removes_mentions(self):
+        text = self.chat_webhook._clean_chat_text({"message": {"text": "<users/12345> こんにちは"}})
+        self.assertEqual(text, "こんにちは")
+
+    def test_handle_chat_event_returns_threaded_response(self):
+        self.chat_webhook._is_valid_token = lambda event: True
+        self.chat_webhook._run_agent_query = lambda prompt, user_id: f"echo:{prompt}:{user_id}"
+        payload = {
+            "type": "MESSAGE",
+            "user": {"name": "users/111"},
+            "message": {"text": "<users/999> テスト", "thread": {"name": "spaces/AAA/threads/BBB"}},
+        }
+        raw_body, status, _headers = self.chat_webhook.handle_chat_event(_FakeRequest(payload))
+        self.assertEqual(status, 200)
+        body = json.loads(raw_body)
+        self.assertEqual(body["thread"]["name"], "spaces/AAA/threads/BBB")
+        self.assertIn("echo:テスト:111", body["text"])
+
+    def test_handle_chat_event_rejects_invalid_token(self):
+        self.chat_webhook._is_valid_token = lambda event: False
+        payload = {"type": "MESSAGE", "message": {"text": "test"}}
+        _raw_body, status, _headers = self.chat_webhook.handle_chat_event(_FakeRequest(payload))
+        self.assertEqual(status, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_cloudbuild_optimizations.py
+++ b/test_cloudbuild_optimizations.py
@@ -25,11 +25,13 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn("DEPLOY_GATEWAY=", self.content)
         self.assertIn("DEPLOY_SCHEDULER=", self.content)
         self.assertIn("DEPLOY_GMAIL_TRIGGER=", self.content)
+        self.assertIn("DEPLOY_CHAT_WEBHOOK=", self.content)
         self.assertIn("DEPLOY_WEB=", self.content)
         self.assertIn("agent/*)", self.content)
         self.assertIn("live_gateway/*)", self.content)
         self.assertIn("scheduler/*)", self.content)
         self.assertIn("gmail_trigger/*)", self.content)
+        self.assertIn("chat_webhook/*)", self.content)
         self.assertIn("web/*)", self.content)
         self.assertIsNone(re.search(r"(?<!\$)\$\{BEFORE_SHA", self.content))
         self.assertIsNone(re.search(r"(?<!\$)\$\{COMMIT_SHA", self.content))
@@ -45,6 +47,7 @@ class CloudBuildOptimizationTests(unittest.TestCase):
         self.assertIn('if [ "${DEPLOY_GATEWAY:-true}" != "true" ]; then', self.content)
         self.assertIn('if [ "${DEPLOY_SCHEDULER:-true}" != "true" ]; then', self.content)
         self.assertIn('if [ "${DEPLOY_GMAIL_TRIGGER:-true}" != "true" ]; then', self.content)
+        self.assertIn('if [ "${DEPLOY_CHAT_WEBHOOK:-true}" != "true" ]; then', self.content)
         self.assertIn('if [ "${DEPLOY_WEB:-true}" != "true" ]; then', self.content)
 
 

--- a/test_connection_env_wiring.py
+++ b/test_connection_env_wiring.py
@@ -103,6 +103,8 @@ class ConnectionEnvWiringTests(unittest.TestCase):
         self.assertIn("pubsub.googleapis.com", self.setup_cloud_source)
         self.assertIn("vuln-agent-gmail-trigger", self.setup_cloud_source)
         self.assertIn("vuln-agent-gmail-watch-refresh", self.setup_cloud_source)
+        self.assertIn("vuln-agent-chat-webhook", self.setup_cloud_source)
+        self.assertIn("vuln-agent-chat-verification-token", self.setup_cloud_source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
- Google Chatでアプリをメンションしたメッセージを受信し、Agent Engineへ問い合わせて返信するWebhookを追加
- 既存の通知送信に加えて、双方向対話を可能化

## 変更内容
- 追加: `chat_webhook/main.py`
  - `handle_chat_event` (Google Chatイベント受信)
  - `MESSAGE` / `ADDED_TO_SPACE` を処理
  - メンション本文抽出 (`argumentText` 優先)
  - `thread` 維持で返信
  - 検証トークン（任意）対応
- 追加: `chat_webhook/requirements.txt`
- 追加: `docs/SETUP_CHAT_INTERACTIVE.md`
- 追加: `test_chat_webhook.py`
- 更新: `setup_cloud.sh`
  - `vuln-agent-chat-webhook` を自動デプロイ
  - `vuln-agent-chat-verification-token` secret入力を追加
- 更新: `cloudbuild.yaml`
  - `chat_webhook/*` 変更検知とデプロイステップを追加
- 更新: `README.md`, `docs/SETUP_CHAT.md`, `test_connection_env_wiring.py`, `test_cloudbuild_optimizations.py`

## テスト
- `python -m unittest test_chat_webhook.py test_gmail_trigger.py test_tool_edge_cases.py test_connection_env_wiring.py test_cloudbuild_optimizations.py -v`
- 21 tests passed

## 補足
- このPRは `fix/gmail-push-trigger-execution` をベースにしたスタックPRです。
