### PR TITLE
fix: 音声挨拶の配信失敗を解消しUIフォールバックを強化

### DIFF
--- a/test_live_audio_reliability.py
+++ b/test_live_audio_reliability.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import unittest
+
+
+LIVE_GATEWAY_APP = Path("live_gateway/app.py")
+LIVE_GATEWAY_API = Path("live_gateway/live_api.py")
+WEB_APP = Path("web/app.js")
+
+
+class LiveAudioReliabilityTests(unittest.TestCase):
+    def test_gateway_emits_greeting_failure_status(self):
+        source = LIVE_GATEWAY_APP.read_text(encoding="utf-8")
+        self.assertIn('"status": "greeting_no_audio"', source)
+        self.assertIn('"status": "greeting_error"', source)
+        self.assertIn("Greeting TTS failed", source)
+
+    def test_frontend_handles_greeting_fallback_speech(self):
+        source = WEB_APP.read_text(encoding="utf-8")
+        self.assertIn("function playGreetingFallbackSpeech", source)
+        self.assertIn("window.speechSynthesis.speak", source)
+        self.assertIn('payload.status === "greeting_no_audio"', source)
+        self.assertIn('payload.status === "greeting_error"', source)
+
+    def test_live_api_uses_current_native_audio_model(self):
+        source = LIVE_GATEWAY_API.read_text(encoding="utf-8")
+        self.assertIn("gemini-2.5-flash-native-audio-preview-12-2025", source)
+        self.assertNotIn("gemini-2.0-flash-live-001", source)
+        self.assertIn("session.send_client_content(", source)
+        self.assertIn("session.send_realtime_input(", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
Live Gateway の音声挨拶が再生されない問題を原因切り分けし、Gateway/UI の両面で再発しにくい構成へ修正しました。

## 原因
- Cloud Run ログで Greeting TTS failed を確認
- 旧Liveモデル (gemini-2.0-flash-live-001) 停止済み
- google-genai SDK の Live 入力形式に不整合があり、挨拶TTS送信時に ValidationError が発生

## 変更点
- live_gateway/live_api.py
  - Liveモデルを gemini-2.5-flash-native-audio-preview-12-2025 に更新
  - テキスト送信を session.send_client_content(...) に変更
  - 音声入力送信を session.send_realtime_input(...) に変更
  - 応答パーツ抽出を _iter_response_parts で互換処理
- live_gateway/app.py
  - 挨拶TTS失敗時に greeting_error / 無音時に greeting_no_audio を通知
  - 挨拶文を live_text で常に送出
- web/app.js
  - 挨拶失敗時のブラウザTTSフォールバック追加
  - 音声オーブのライン描画を連続曲線に変更
  - フォールバック/再生状態の遷移整理（挨拶待機解除、停止時のクリーンアップ）
- 	est_live_audio_reliability.py
  - モデル設定、Gateway通知、フロントフォールバック分岐のテスト追加

## テスト結果
- python -m unittest live_gateway.test_health_endpoints test_live_audio_reliability -v : PASS
- 
ode --check web/app.js : PASS
- Cloud Build: 490641db-7456-48d0-a170-28ba9824fd1b SUCCESS
- 実機確認 (WebSocket):
  - live_start 後に live_status: started を受信
  - live_audio (mime_type=udio/pcm;rate=24000) を受信
  - greeting_error が解消され、挨拶音声配信を確認