### PR TITLE
fix: 音声再生の途切れ改善とライブ表示の日本語化

### DIFF
--- a/test_live_audio_reliability.py
+++ b/test_live_audio_reliability.py
@@ -13,6 +13,8 @@ class LiveAudioReliabilityTests(unittest.TestCase):
         self.assertIn('"status": "greeting_no_audio"', source)
         self.assertIn('"status": "greeting_error"', source)
         self.assertIn("Greeting TTS failed", source)
+        self.assertIn('"text": response_text', source)
+        self.assertNotIn('"text": response.text', source)
 
     def test_frontend_handles_greeting_fallback_speech(self):
         source = WEB_APP.read_text(encoding="utf-8")
@@ -20,6 +22,9 @@ class LiveAudioReliabilityTests(unittest.TestCase):
         self.assertIn("window.speechSynthesis.speak", source)
         self.assertIn('payload.status === "greeting_no_audio"', source)
         self.assertIn('payload.status === "greeting_error"', source)
+        self.assertIn("function extractJapaneseText", source)
+        self.assertIn("function drainPlaybackQueue", source)
+        self.assertIn("playbackQueue.push", source)
 
     def test_live_api_uses_current_native_audio_model(self):
         source = LIVE_GATEWAY_API.read_text(encoding="utf-8")


### PR DESCRIPTION
## 概要
音声対話で発生していた『早口・ぶつ切れ再生』と、Liveテキストに英語の不要メッセージが出る問題を修正しました。

## 変更点
- web/app.js
  - live_audio を即時上書き再生からキュー再生へ変更
  - 再生終了の判定をアイドルタイマーで安定化し、途中切断を抑制
  - arge_in / stop 時に再生キューを確実に破棄
  - live_text を日本語抽出して表示（英語の不要文を非表示化）
- live_gateway/app.py
  - ライブ音声認識中の逐次文字起こしをUIへ直接流さないよう調整
  - 音声応答時は最終応答テキストのみ live_text 送信
- 	est_live_audio_reliability.py
  - 上記挙動の回帰テストを追加

## テスト結果
- python -m unittest live_gateway.test_health_endpoints test_live_audio_reliability -v : PASS
- 
ode --check web/app.js : PASS
- Cloud Build: d6a3cf99-9c14-49f9-9979-edce3f0a5a01 SUCCESS
- WebSocket確認:
  - live_start 後に live_status: started
  - live_text: こんにちは。要件を教えてください。
  - live_audio 受信を確認