### PR TITLE
fix: setup_cloud.shでEventarc APIを有効化

### DIFF
--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -72,6 +72,7 @@ APIS=(
   bigquery.googleapis.com
   cloudbuild.googleapis.com
   cloudfunctions.googleapis.com
+  eventarc.googleapis.com
   cloudscheduler.googleapis.com
   run.googleapis.com
   secretmanager.googleapis.com


### PR DESCRIPTION
## 概要
setup_cloud.sh の API 有効化リストに ventarc.googleapis.com を追加しました。

## 変更点
- setup_cloud.sh
  - APIS 配列に ventarc.googleapis.com を追加

## テスト結果
- 差分確認: setup_cloud.sh 1行追加のみ
- 備考: Windows環境のCRLF影響で ash -n setup_cloud.sh は実行不可（LF変換後に実行可能）