### PR TITLE
Fix live voice barge-in overlap and stale TTS playback

### DIFF
--- a/test_live_audio_reliability.py
+++ b/test_live_audio_reliability.py
@@ -13,6 +13,9 @@ class LiveAudioReliabilityTests(unittest.TestCase):
         self.assertIn('"status": "greeting_no_audio"', source)
         self.assertIn('"status": "greeting_error"', source)
         self.assertIn("Greeting TTS failed", source)
+        self.assertIn("if payload.get(\"type\") == \"barge_in\":", source)
+        self.assertIn("if tts_task:", source)
+        self.assertIn("tts_task.cancel()", source)
         self.assertIn('"text": response_text', source)
         self.assertNotIn('"text": response.text', source)
 
@@ -22,6 +25,8 @@ class LiveAudioReliabilityTests(unittest.TestCase):
         self.assertIn("window.speechSynthesis.speak", source)
         self.assertIn('payload.status === "greeting_no_audio"', source)
         self.assertIn('payload.status === "greeting_error"', source)
+        self.assertIn("function suppressIncomingLiveAudio", source)
+        self.assertIn("if (Date.now() < suppressLiveAudioUntilMs)", source)
         self.assertIn("function extractJapaneseText", source)
         self.assertIn("function drainPlaybackQueue", source)
         self.assertIn("playbackQueue.push", source)


### PR DESCRIPTION
## Summary
- generate first greeting via Agent Engine while keeping fallback
- cancel in-flight greeting/response/TTS tasks on barge-in in live gateway
- suppress stale incoming live audio for a short window on frontend to avoid overlapping playback
- stop speech synthesis fallback when playback is interrupted
- add reliability assertions for barge-in cancellation and suppression

## Test
- python -m unittest test_live_audio_reliability.py -v