### PR TITLE
Improve listening-state visibility in voice UI

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -228,9 +228,13 @@ function setStatus(online, message) {
 // ── Audio Mode ──────────────────────────────────────────
 function setMode(nextMode) {
   mode = nextMode;
+  const isListening = String(mode).startsWith("listening");
+  document.body.classList.toggle("mode-listening", isListening);
+  voiceSessionOverlay?.classList.toggle("listening-active", isListening);
+
   const labelMap = {
     idle: "Idle",
-    listening: "Listening",
+    listening: "Listening (Mic ON)",
     speaking: "Agent Speaking",
     "awaiting-greeting": "Agent Greeting...",
   };

--- a/web/style.css
+++ b/web/style.css
@@ -599,6 +599,42 @@ body {
   min-width: 80px;
 }
 
+body.mode-listening .audio-bar {
+  border-top-color: rgba(34, 197, 94, 0.55);
+  box-shadow: inset 0 1px 0 rgba(34, 197, 94, 0.25);
+}
+
+body.mode-listening .audio-level-container {
+  background: rgba(10, 24, 18, 0.9);
+  border: 1px solid rgba(34, 197, 94, 0.45);
+}
+
+body.mode-listening .audio-level-bar {
+  background: linear-gradient(90deg, #22c55e, #86efac);
+  box-shadow: 0 0 10px rgba(34, 197, 94, 0.35);
+}
+
+body.mode-listening .audio-status-text {
+  color: #bbf7d0;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+body.mode-listening .voice-orb.voice-orb-listening .voice-orb-core {
+  background: #22c55e;
+  box-shadow: 0 0 0 8px rgba(34, 197, 94, 0.14);
+}
+
+body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
+  border-color: rgba(34, 197, 94, 0.9);
+  animation: voice-listening-pulse 820ms ease-out infinite;
+}
+
+.voice-session-overlay.listening-active .voice-orb-large-path {
+  stroke: #bbf7d0;
+  filter: drop-shadow(0 0 14px rgba(34, 197, 94, 0.42));
+}
+
 /* ── Chat Input Form ─────────────────────────── */
 .chat-input-form {
   display: flex;
@@ -914,6 +950,17 @@ body {
   100% {
     transform: scale(1.45);
     opacity: 0.15;
+  }
+}
+
+@keyframes voice-listening-pulse {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(1.3);
+    opacity: 0.25;
   }
 }
 


### PR DESCRIPTION
## Summary
- add explicit listening-state UI flag in setMode()
- update status text to Listening (Mic ON)
- add stronger visual feedback while listening (green highlight, orb pulse, audio bar emphasis)
- tint voice overlay orb when microphone is actively listening

## Test
- python -m unittest test_live_audio_reliability.py -v