### PR TITLE
Add Entra ID OIDC SSO and authenticated WebSocket flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ bash test_agent.sh "Chatへの接続を確認して"
 bash test_agent.sh "SBOMでlog4jを検索して結果を教えて"
 ```
 
+## Entra ID SSO (OIDC)
+Live Gateway は OIDC 認証を有効化できます（Entra ID 対応）。
+
+必要環境変数（`live_gateway`）:
+- `OIDC_ENABLED=true`
+- `OIDC_TENANT_ID=<entra-tenant-id>`
+- `OIDC_CLIENT_ID=<app-registration-client-id>`
+- `OIDC_CLIENT_SECRET=<client-secret>`
+- `OIDC_REDIRECT_URI=https://<live-gateway-domain>/auth/callback`
+- `OIDC_SESSION_SECRET=<32bytes以上のランダム文字列>`
+
+任意:
+- `OIDC_SCOPES`（デフォルト: `openid profile email`）
+- `OIDC_ISSUER`（未指定時は tenant から自動生成）
+
+動作:
+- `/auth/login` で Entra ID へリダイレクト
+- `/auth/callback` でログイン完了し、セッションCookieを発行
+- `/ws` は認証済みセッションがないと接続拒否
+
 ## よく使う運用コマンド
 再デプロイ:
 ```bash

--- a/live_gateway/app.py
+++ b/live_gateway/app.py
@@ -1,14 +1,21 @@
 import asyncio
 import base64
 import binascii
+import hashlib
+import hmac
 import json
 import logging
 import os
+import secrets
 import time
+import urllib.parse
+import urllib.request
 import uuid
 from typing import Any
 
+import jwt
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 import vertexai
 from vertexai import Client
@@ -25,6 +32,22 @@ LIVE_GREETING_TEXT = os.environ.get(
     "LIVE_GREETING_TEXT",
     "こんにちは。脆弱性管理AIエージェントです。ご要望をどうぞ。",
 )
+OIDC_ENABLED = os.environ.get("OIDC_ENABLED", "false").strip().lower() in {"1", "true", "yes", "on"}
+OIDC_TENANT_ID = os.environ.get("OIDC_TENANT_ID", "").strip()
+OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", "").strip()
+OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", "").strip()
+OIDC_ISSUER = os.environ.get("OIDC_ISSUER", "").strip() or (
+    f"https://login.microsoftonline.com/{OIDC_TENANT_ID}/v2.0" if OIDC_TENANT_ID else ""
+)
+OIDC_SCOPES = os.environ.get("OIDC_SCOPES", "openid profile email").strip()
+OIDC_REDIRECT_URI = os.environ.get("OIDC_REDIRECT_URI", "").strip()
+OIDC_SESSION_SECRET = os.environ.get("OIDC_SESSION_SECRET", "").strip()
+OIDC_SESSION_COOKIE_NAME = os.environ.get("OIDC_SESSION_COOKIE_NAME", "vuln_agent_session").strip()
+OIDC_STATE_COOKIE_NAME = os.environ.get("OIDC_STATE_COOKIE_NAME", "vuln_agent_oidc_state").strip()
+OIDC_SESSION_TTL_SEC = 8 * 60 * 60
+OIDC_STATE_TTL_SEC = 10 * 60
+_oidc_metadata_cache: dict[str, Any] | None = None
+_oidc_metadata_cache_at = 0.0
 
 TOOL_DISPLAY_MAP: dict[str, dict[str, str]] = {
     "get_sidfm_emails":         {"label": "SIDfm脆弱性メールを取得中",     "icon": "mail"},
@@ -95,6 +118,152 @@ def _safe_healthz_headers(request: Request) -> dict[str, str]:
     }
 
 
+def _base64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("utf-8").rstrip("=")
+
+
+def _base64url_decode(raw: str) -> bytes:
+    padded = raw + ("=" * (-len(raw) % 4))
+    return base64.urlsafe_b64decode(padded.encode("utf-8"))
+
+
+def _sign_value(payload: dict[str, Any], ttl_sec: int) -> str:
+    if not OIDC_SESSION_SECRET:
+        raise RuntimeError("OIDC_SESSION_SECRET is required when OIDC is enabled.")
+    body = dict(payload)
+    body["exp"] = int(time.time()) + int(ttl_sec)
+    body_json = json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    body_b64 = _base64url_encode(body_json)
+    sig = hmac.new(
+        OIDC_SESSION_SECRET.encode("utf-8"),
+        body_b64.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return f"{body_b64}.{_base64url_encode(sig)}"
+
+
+def _verify_signed_value(value: str | None) -> dict[str, Any] | None:
+    if not value or "." not in value or not OIDC_SESSION_SECRET:
+        return None
+    body_b64, sig_b64 = value.split(".", 1)
+    expected_sig = hmac.new(
+        OIDC_SESSION_SECRET.encode("utf-8"),
+        body_b64.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    provided_sig = _base64url_decode(sig_b64)
+    if not hmac.compare_digest(expected_sig, provided_sig):
+        return None
+    payload = json.loads(_base64url_decode(body_b64).decode("utf-8"))
+    if int(payload.get("exp", 0)) < int(time.time()):
+        return None
+    return payload
+
+
+def _is_oidc_ready() -> bool:
+    return bool(
+        OIDC_ENABLED
+        and OIDC_ISSUER
+        and OIDC_CLIENT_ID
+        and OIDC_CLIENT_SECRET
+        and OIDC_SESSION_SECRET
+    )
+
+
+def _resolve_base_url_from_request(request: Request) -> str:
+    forwarded_proto = (request.headers.get("x-forwarded-proto") or "").strip()
+    scheme = forwarded_proto or request.url.scheme
+    host = request.headers.get("host") or request.url.netloc
+    return f"{scheme}://{host}"
+
+
+def _resolve_redirect_uri(request: Request) -> str:
+    if OIDC_REDIRECT_URI:
+        return OIDC_REDIRECT_URI
+    return f"{_resolve_base_url_from_request(request)}/auth/callback"
+
+
+def _get_oidc_metadata() -> dict[str, Any]:
+    global _oidc_metadata_cache, _oidc_metadata_cache_at
+    if _oidc_metadata_cache and (time.time() - _oidc_metadata_cache_at < 3600):
+        return _oidc_metadata_cache
+    if not OIDC_ISSUER:
+        raise RuntimeError("OIDC_ISSUER is not configured.")
+    url = f"{OIDC_ISSUER.rstrip('/')}/.well-known/openid-configuration"
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        metadata = json.loads(resp.read().decode("utf-8", errors="replace"))
+    _oidc_metadata_cache = metadata
+    _oidc_metadata_cache_at = time.time()
+    return metadata
+
+
+def _exchange_code_for_token(code: str, redirect_uri: str) -> dict[str, Any]:
+    metadata = _get_oidc_metadata()
+    token_endpoint = metadata.get("token_endpoint")
+    if not token_endpoint:
+        raise RuntimeError("OIDC token_endpoint not found.")
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "authorization_code",
+            "client_id": OIDC_CLIENT_ID,
+            "client_secret": OIDC_CLIENT_SECRET,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        token_endpoint,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _validate_id_token(id_token: str, expected_nonce: str) -> dict[str, Any]:
+    metadata = _get_oidc_metadata()
+    jwks_uri = metadata.get("jwks_uri")
+    issuer = metadata.get("issuer") or OIDC_ISSUER
+    if not jwks_uri:
+        raise RuntimeError("OIDC jwks_uri not found.")
+    jwk_client = jwt.PyJWKClient(jwks_uri)
+    signing_key = jwk_client.get_signing_key_from_jwt(id_token)
+    claims = jwt.decode(
+        id_token,
+        signing_key.key,
+        algorithms=["RS256", "RS384", "RS512"],
+        audience=OIDC_CLIENT_ID,
+        issuer=issuer,
+    )
+    if expected_nonce and claims.get("nonce") != expected_nonce:
+        raise RuntimeError("OIDC nonce mismatch.")
+    return claims
+
+
+def _build_post_login_redirect(next_url: str) -> str:
+    safe_next = (next_url or "").strip()
+    if not safe_next:
+        return "/"
+    parsed = urllib.parse.urlparse(safe_next)
+    if parsed.scheme or parsed.netloc:
+        return "/"
+    if not safe_next.startswith("/"):
+        return "/"
+    return safe_next
+
+
+def _get_session_user_from_cookie(cookies: dict[str, str]) -> dict[str, Any] | None:
+    payload = _verify_signed_value(cookies.get(OIDC_SESSION_COOKIE_NAME))
+    if not payload:
+        return None
+    return {
+        "sub": payload.get("sub", ""),
+        "name": payload.get("name", ""),
+        "email": payload.get("email", ""),
+    }
+
+
 def _is_error_response(response_data: Any) -> bool:
     return isinstance(response_data, dict) and (
         response_data.get("status") == "error" or "error" in response_data
@@ -150,7 +319,7 @@ def _init_vertex() -> Client:
 
 
 async def _query_agent(
-    client: Client, message: str, websocket: WebSocket,
+    client: Client, message: str, websocket: WebSocket, user_id: str,
 ) -> dict[str, Any]:
     app_client = client.agent_engines.get(name=AGENT_RESOURCE_NAME)
     chunks: list[str] = []
@@ -171,10 +340,7 @@ async def _query_agent(
         },
     })
 
-    async for event in app_client.async_stream_query(
-        user_id="live_gateway",
-        message=message,
-    ):
+    async for event in app_client.async_stream_query(user_id=user_id, message=message):
         logger.debug("Agent event type: %s", type(event))
 
         if isinstance(event, dict):
@@ -294,10 +460,109 @@ def ping():
     return {"status": "ok"}
 
 
+@app.get("/auth/me")
+def auth_me(request: Request):
+    if not OIDC_ENABLED:
+        return {"enabled": False, "authenticated": True, "user": {"sub": "anonymous"}}
+    user = _get_session_user_from_cookie(request.cookies)
+    return {"enabled": True, "authenticated": bool(user), "user": user}
+
+
+@app.get("/auth/login")
+def auth_login(request: Request, next: str = "/"):
+    if not _is_oidc_ready():
+        return {"status": "error", "message": "OIDC is not fully configured."}
+    metadata = _get_oidc_metadata()
+    authorization_endpoint = metadata.get("authorization_endpoint")
+    if not authorization_endpoint:
+        return {"status": "error", "message": "OIDC authorization_endpoint not found."}
+
+    state = secrets.token_urlsafe(24)
+    nonce = secrets.token_urlsafe(24)
+    redirect_uri = _resolve_redirect_uri(request)
+    params = {
+        "client_id": OIDC_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": redirect_uri,
+        "response_mode": "query",
+        "scope": OIDC_SCOPES,
+        "state": state,
+        "nonce": nonce,
+    }
+    auth_url = f"{authorization_endpoint}?{urllib.parse.urlencode(params)}"
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key=OIDC_STATE_COOKIE_NAME,
+        value=_sign_value(
+            {"state": state, "nonce": nonce, "next": _build_post_login_redirect(next)},
+            ttl_sec=OIDC_STATE_TTL_SEC,
+        ),
+        httponly=True,
+        secure=True,
+        samesite="none",
+        max_age=OIDC_STATE_TTL_SEC,
+        path="/",
+    )
+    return response
+
+
+@app.get("/auth/callback")
+def auth_callback(request: Request, code: str = "", state: str = ""):
+    if not _is_oidc_ready():
+        return {"status": "error", "message": "OIDC is not fully configured."}
+
+    state_cookie = _verify_signed_value(request.cookies.get(OIDC_STATE_COOKIE_NAME))
+    if not code or not state or not state_cookie:
+        return {"status": "error", "message": "Missing OIDC callback parameters."}
+    if state_cookie.get("state") != state:
+        return {"status": "error", "message": "OIDC state mismatch."}
+
+    token_payload = _exchange_code_for_token(code, _resolve_redirect_uri(request))
+    id_token = (token_payload.get("id_token") or "").strip()
+    if not id_token:
+        return {"status": "error", "message": "id_token was not returned."}
+    claims = _validate_id_token(id_token, expected_nonce=str(state_cookie.get("nonce", "")))
+
+    session_payload = {
+        "sub": claims.get("sub", ""),
+        "name": claims.get("name", claims.get("preferred_username", "")),
+        "email": claims.get("preferred_username", claims.get("email", "")),
+    }
+    next_url = _build_post_login_redirect(str(state_cookie.get("next", "/")))
+
+    response = RedirectResponse(url=next_url, status_code=302)
+    response.delete_cookie(OIDC_STATE_COOKIE_NAME, path="/")
+    response.set_cookie(
+        key=OIDC_SESSION_COOKIE_NAME,
+        value=_sign_value(session_payload, ttl_sec=OIDC_SESSION_TTL_SEC),
+        httponly=True,
+        secure=True,
+        samesite="none",
+        max_age=OIDC_SESSION_TTL_SEC,
+        path="/",
+    )
+    return response
+
+
+@app.post("/auth/logout")
+def auth_logout():
+    response = RedirectResponse(url="/", status_code=302)
+    response.delete_cookie(OIDC_SESSION_COOKIE_NAME, path="/")
+    response.delete_cookie(OIDC_STATE_COOKIE_NAME, path="/")
+    return response
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
+    ws_user = _get_session_user_from_cookie(websocket.cookies) if OIDC_ENABLED else {"sub": "anonymous"}
+    if OIDC_ENABLED and not ws_user:
+        await websocket.close(code=4401, reason="Unauthorized")
+        return
     await websocket.accept()
     client = _init_vertex()
+    ws_conversation_id = uuid.uuid4().hex[:10]
+    ws_user_id = f"live_gateway:{ws_user.get('sub', 'anonymous')}:{ws_conversation_id}"
     audio_queue: asyncio.Queue[tuple[bytes | None, int]] = asyncio.Queue()
     live_client: GeminiLiveClient | None = None
     live_task: asyncio.Task | None = None
@@ -413,7 +678,7 @@ async def websocket_endpoint(websocket: WebSocket):
             if not transcript:
                 return
             last_response_index = len(transcript_parts)
-            agent_response = await _query_agent(client, transcript, websocket)
+            agent_response = await _query_agent(client, transcript, websocket, ws_user_id)
             await _safe_send(websocket, agent_response)
             response_text = agent_response.get("text", "")
             if response_text:
@@ -476,7 +741,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     )
                     continue
 
-                response = await _query_agent(client, message, websocket)
+                response = await _query_agent(client, message, websocket, ws_user_id)
                 await websocket.send_text(json.dumps(response, ensure_ascii=False))
                 continue
 

--- a/live_gateway/requirements.txt
+++ b/live_gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.115.0
 uvicorn>=0.30.0
 google-cloud-aiplatform[agent_engines]>=1.112.0
 google-genai>=1.0.0
+PyJWT[crypto]>=2.8.0

--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,14 @@
             <i data-lucide="wifi-off"></i>
             <span>Disconnect</span>
           </button>
+          <button id="login-button" class="btn btn-outline" type="button">
+            <i data-lucide="log-in"></i>
+            <span>Login</span>
+          </button>
+          <button id="logout-button" class="btn btn-outline" type="button">
+            <i data-lucide="log-out"></i>
+            <span>Logout</span>
+          </button>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add OIDC auth endpoints to live gateway (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`)
- integrate Entra ID OIDC token validation via OpenID metadata + JWKS
- issue signed session cookie and protect `/ws` with auth
- update agent request user_id generation to be user-scoped instead of fixed value
- add Login/Logout controls in web UI and auth state checks before connect
- document Entra OIDC configuration in README
- add PyJWT dependency for JWT validation

## Validation
- node --check web/app.js
- python -m unittest live_gateway/test_health_endpoints.py -v
