### PR TITLE
Add Entra OIDC SSO and chat notification deadline formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ gcloud functions logs read vuln-agent-chat-webhook --region=asia-northeast1 --li
   - `list_sbom_package_versions`
   - `get_sbom_entry_by_purl`
 - Chat: `send_vulnerability_alert`, `send_simple_message`, `check_chat_connection`, `list_space_members`
+  - `send_vulnerability_alert` は定型フォーマット通知（対象機器/脆弱性リンク/CVSS/依頼内容/対応完了目標）に対応
+  - 対応期限は CVSS・公開/内部リソース・悪用実績/Exploit 公開有無ルールを優先
 - 履歴: `log_vulnerability_history`
 - A2A: `register_remote_agent`, `call_remote_agent`, `list_registered_agents`, `create_jira_ticket_request`, `create_approval_request`
 - 権限可視化/柔軟参照: `get_runtime_capabilities`, `inspect_bigquery_capabilities`, `list_bigquery_tables`, `run_bigquery_readonly_query`

--- a/test_chat_tools.py
+++ b/test_chat_tools.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sys
 import types
 import unittest
+from datetime import date
 
 
 ROOT = Path(__file__).resolve().parent
@@ -231,6 +232,35 @@ class ChatToolsTests(unittest.TestCase):
         """Verify the text body uses <email> format not <users/email>."""
         self.assertIn('f"<{email}>"', self.chat_tools_source)
         self.assertNotIn('f"<users/{email}>"', self.chat_tools_source)
+
+    def test_deadline_rule_public_cvss8(self):
+        deadline = self.chat_tools._calculate_deadline(
+            severity="高",
+            cvss_score=8.2,
+            resource_type="public",
+            now=date(2026, 2, 15),  # Sunday
+        )
+        self.assertEqual(deadline, "2026/2/27")
+
+    def test_deadline_rule_internal_cvss8(self):
+        deadline = self.chat_tools._calculate_deadline(
+            severity="高",
+            cvss_score=8.5,
+            resource_type="internal",
+            now=date(2026, 2, 15),
+        )
+        self.assertEqual(deadline, "2026/5/15")
+
+    def test_deadline_rule_public_cvss9_with_exploit(self):
+        deadline = self.chat_tools._calculate_deadline(
+            severity="緊急",
+            cvss_score=9.1,
+            resource_type="public",
+            exploit_confirmed=True,
+            exploit_code_public=True,
+            now=date(2026, 2, 15),
+        )
+        self.assertEqual(deadline, "2026/2/20")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Entra ID OIDC SSO to live gateway
- protect websocket endpoint with authenticated session
- add login/logout flow to web UI
- format chat notification text to requested Japanese template
- apply CVSS/resource/exploit based deadline rules for notification target date

## Validation
- node --check web/app.js
- python -m unittest live_gateway/test_health_endpoints.py -v
- python -m unittest test_chat_tools.py test_tool_edge_cases.py test_connection_env_wiring.py -v
