### PR TITLE
fix: harden auth/session handling and add output regression tests

### DIFF
--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -1,126 +1,125 @@
 """
-Tools package for Vulnerability Management Agent
+Tools package for Vulnerability Management Agent.
+
+This module keeps import-time robustness high so test discovery can run even
+when optional external dependencies (googleapiclient/vertexai/etc.) are absent.
+Missing dependencies are surfaced when the corresponding tool function is called.
 """
 
-from .gmail_tools import (
-    get_sidfm_emails,
-    get_unread_emails,
-    mark_email_as_read,
-    check_gmail_connection,
-)
-from .sheets_tools import (
-    search_sbom_by_purl,
-    search_sbom_by_product,
-    get_affected_systems,
-    get_owner_mapping,
-    get_sbom_contents,
-    list_sbom_package_types,
-    count_sbom_packages_by_type,
-    list_sbom_packages_by_type,
-    list_sbom_package_versions,
-    get_sbom_entry_by_purl,
-)
-from .chat_tools import (
-    send_vulnerability_alert,
-    send_simple_message,
-    check_chat_connection,
-    list_space_members,
-)
-from .history_tools import log_vulnerability_history
-from .a2a_tools import (
-    register_remote_agent,
-    call_remote_agent,
-    list_registered_agents,
-    create_jira_ticket_request,
-    create_approval_request,
-)
-from .capability_tools import (
-    get_runtime_capabilities,
-    inspect_bigquery_capabilities,
-    list_bigquery_tables,
-    run_bigquery_readonly_query,
-)
-from .web_tools import (
-    web_search,
-    fetch_web_content,
-)
-from .vuln_intel_tools import (
-    get_nvd_cve_details,
-    search_osv_vulnerabilities,
-)
-from .granular_tools import (
-    list_sidfm_email_subjects,
-    list_unread_email_ids,
-    get_email_preview_by_id,
-    get_chat_space_info,
-    list_chat_member_emails,
-    build_history_record_preview,
-    list_registered_agent_ids,
-    get_registered_agent_details,
-    get_configured_bigquery_tables,
-    check_bigquery_readability_summary,
-    list_web_search_urls,
-    get_web_content_excerpt,
-    get_nvd_cvss_summary,
-    list_osv_vulnerability_ids,
-    save_vulnerability_history_minimal,
-)
+from __future__ import annotations
 
-__all__ = [
-    # Gmail
-    "get_sidfm_emails",
-    "get_unread_emails",
-    "mark_email_as_read",
-    "check_gmail_connection",
-    # Sheets
-    "search_sbom_by_purl",
-    "search_sbom_by_product",
-    "get_affected_systems",
-    "get_owner_mapping",
-    "get_sbom_contents",
-    "list_sbom_package_types",
-    "count_sbom_packages_by_type",
-    "list_sbom_packages_by_type",
-    "list_sbom_package_versions",
-    "get_sbom_entry_by_purl",
-    # Chat
-    "send_vulnerability_alert",
-    "send_simple_message",
-    "check_chat_connection",
-    "list_space_members",
-    # History
-    "log_vulnerability_history",
-    # A2A
-    "register_remote_agent",
-    "call_remote_agent",
-    "list_registered_agents",
-    "create_jira_ticket_request",
-    "create_approval_request",
-    # Capability
-    "get_runtime_capabilities",
-    "inspect_bigquery_capabilities",
-    "list_bigquery_tables",
-    "run_bigquery_readonly_query",
-    # Web
-    "web_search",
-    "fetch_web_content",
-    # Vulnerability Intel
-    "get_nvd_cve_details",
-    "search_osv_vulnerabilities",
-    # Granular
-    "list_sidfm_email_subjects",
-    "list_unread_email_ids",
-    "get_email_preview_by_id",
-    "get_chat_space_info",
-    "list_chat_member_emails",
-    "build_history_record_preview",
-    "list_registered_agent_ids",
-    "get_registered_agent_details",
-    "get_configured_bigquery_tables",
-    "check_bigquery_readability_summary",
-    "list_web_search_urls",
-    "get_web_content_excerpt",
-    "get_nvd_cvss_summary",
-    "list_osv_vulnerability_ids",
-    "save_vulnerability_history_minimal",
+from importlib import import_module
+from typing import Any
+
+_EXPORT_SPECS: list[tuple[str, list[str]]] = [
+    (
+        "gmail_tools",
+        [
+            "get_sidfm_emails",
+            "get_unread_emails",
+            "mark_email_as_read",
+            "check_gmail_connection",
+        ],
+    ),
+    (
+        "sheets_tools",
+        [
+            "search_sbom_by_purl",
+            "search_sbom_by_product",
+            "get_affected_systems",
+            "get_owner_mapping",
+            "get_sbom_contents",
+            "list_sbom_package_types",
+            "count_sbom_packages_by_type",
+            "list_sbom_packages_by_type",
+            "list_sbom_package_versions",
+            "get_sbom_entry_by_purl",
+        ],
+    ),
+    (
+        "chat_tools",
+        [
+            "send_vulnerability_alert",
+            "send_simple_message",
+            "check_chat_connection",
+            "list_space_members",
+        ],
+    ),
+    ("history_tools", ["log_vulnerability_history"]),
+    (
+        "a2a_tools",
+        [
+            "register_remote_agent",
+            "call_remote_agent",
+            "list_registered_agents",
+            "create_jira_ticket_request",
+            "create_approval_request",
+        ],
+    ),
+    (
+        "capability_tools",
+        [
+            "get_runtime_capabilities",
+            "inspect_bigquery_capabilities",
+            "list_bigquery_tables",
+            "run_bigquery_readonly_query",
+        ],
+    ),
+    ("web_tools", ["web_search", "fetch_web_content"]),
+    ("vuln_intel_tools", ["get_nvd_cve_details", "search_osv_vulnerabilities"]),
+    (
+        "granular_tools",
+        [
+            "list_sidfm_email_subjects",
+            "list_unread_email_ids",
+            "get_email_preview_by_id",
+            "get_chat_space_info",
+            "list_chat_member_emails",
+            "build_history_record_preview",
+            "list_registered_agent_ids",
+            "get_registered_agent_details",
+            "get_configured_bigquery_tables",
+            "check_bigquery_readability_summary",
+            "list_web_search_urls",
+            "get_web_content_excerpt",
+            "get_nvd_cvss_summary",
+            "list_osv_vulnerability_ids",
+            "save_vulnerability_history_minimal",
+        ],
+    ),
 ]
+
+
+def _missing_tool_factory(tool_name: str, module_name: str, import_error: Exception):
+    def _missing_tool(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        _ = (args, kwargs)
+        return {
+            "status": "error",
+            "message": (
+                f"Tool '{tool_name}' is unavailable because module '{module_name}' could not be imported: "
+                f"{import_error}"
+            ),
+        }
+
+    _missing_tool.__name__ = tool_name
+    return _missing_tool
+
+
+for _module_name, _tool_names in _EXPORT_SPECS:
+    try:
+        _module = import_module(f".{_module_name}", package=__name__)
+        for _tool_name in _tool_names:
+            if hasattr(_module, _tool_name):
+                globals()[_tool_name] = getattr(_module, _tool_name)
+            else:
+                globals()[_tool_name] = _missing_tool_factory(
+                    _tool_name,
+                    _module_name,
+                    AttributeError(f"missing attribute '{_tool_name}'"),
+                )
+    except Exception as _exc:
+        for _tool_name in _tool_names:
+            globals()[_tool_name] = _missing_tool_factory(_tool_name, _module_name, _exc)
+
+
+__all__ = [name for _, names in _EXPORT_SPECS for name in names]

--- a/live_gateway/test_health_endpoints.py
+++ b/live_gateway/test_health_endpoints.py
@@ -66,6 +66,20 @@ class HealthEndpointTests(unittest.TestCase):
         self.assertIn('for field in direct_fields', source)
         self.assertIn('for container_key in ("error", "result", "response")', source)
 
+    def test_cors_configuration_supports_cookie_auth(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn("def _resolve_cors_origins", source)
+        self.assertIn("CORS_ALLOW_ORIGINS", source)
+        self.assertIn('if OIDC_ENABLED and "*" in origins', source)
+        self.assertIn("allow_origins=_resolve_cors_origins()", source)
+        self.assertIn("allow_credentials=OIDC_ENABLED", source)
+
+    def test_cookie_samesite_is_dynamic(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn("def _cookie_samesite_value", source)
+        self.assertIn('return "none" if _cookie_secure_flag(request) else "lax"', source)
+        self.assertIn("samesite=_cookie_samesite_value(request)", source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_agent.py
+++ b/test_agent.py
@@ -1,18 +1,44 @@
-import vertexai
-from vertexai import agent_engines
+import os
+import unittest
 
-PROJECT_ID = "agenticai-485616"
-LOCATION = "asia-northeast1"
-AGENT_ENGINE_ID = "2793436833713750016"
 
-vertexai.init(project=PROJECT_ID, location=LOCATION)
-agent = agent_engines.get(f"projects/{PROJECT_ID}/locations/{LOCATION}/reasoningEngines/{AGENT_ENGINE_ID}")
+class AgentIntegrationTests(unittest.TestCase):
+    def test_agent_stream_query_smoke(self):
+        run_flag = os.environ.get("RUN_AGENT_INTEGRATION_TEST", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        if not run_flag:
+            self.skipTest("Set RUN_AGENT_INTEGRATION_TEST=1 to run integration test.")
 
-for event in agent.stream_query(
-    user_id="test-user",
-    message="log4jを検索して"
-):
-    if 'content' in event:
-        for part in event['content'].get('parts', []):
-            if 'text' in part:
-                print(part['text'])
+        try:
+            import vertexai
+            from vertexai import agent_engines
+        except Exception as exc:
+            self.skipTest(f"vertexai is not available: {exc}")
+
+        project_id = (os.environ.get("GCP_PROJECT_ID") or "").strip()
+        location = (os.environ.get("GCP_LOCATION") or "asia-northeast1").strip()
+        agent_engine_id = (os.environ.get("AGENT_ENGINE_ID") or "").strip()
+        if not project_id or not agent_engine_id:
+            self.skipTest("GCP_PROJECT_ID and AGENT_ENGINE_ID are required for integration test.")
+
+        vertexai.init(project=project_id, location=location)
+        agent = agent_engines.get(
+            f"projects/{project_id}/locations/{location}/reasoningEngines/{agent_engine_id}"
+        )
+
+        chunks = []
+        for event in agent.stream_query(user_id="test-user", message="log4jを検索して"):
+            content = event.get("content") if isinstance(event, dict) else None
+            parts = (content or {}).get("parts", []) if isinstance(content, dict) else []
+            for part in parts:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    chunks.append(part["text"])
+
+        self.assertTrue(chunks, "No text chunks were returned from stream_query.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_chat_tools.py
+++ b/test_chat_tools.py
@@ -262,6 +262,56 @@ class ChatToolsTests(unittest.TestCase):
         )
         self.assertEqual(deadline, "2026/2/20")
 
+    def test_structured_alert_text_matches_required_sections(self):
+        text = self.chat_tools._build_structured_alert_text(
+            affected_systems=["Almalinux8", "Almalinux9"],
+            vulnerability_id="CVE-2026-0001",
+            title="OpenSSL issue",
+            cvss_score=8.8,
+            vulnerability_links={
+                "Almalinux8": "https://sid.softek.jp/filter/sinfo/60846",
+                "Almalinux9": "https://sid.softek.jp/filter/sinfo/53834",
+            },
+            deadline="2026/2/17",
+            remediation=None,
+        )
+
+        expected = (
+            "【対象の機器/アプリ】\n"
+            "Almalinux8\n"
+            "Almalinux9\n\n"
+            "【脆弱性情報】（リンク貼り付け）\n"
+            "Almalinux8\n"
+            "https://sid.softek.jp/filter/sinfo/60846\n\n"
+            "Almalinux9\n"
+            "https://sid.softek.jp/filter/sinfo/53834\n\n"
+            "【CVSSスコア】\n"
+            "8以上\n\n"
+            "【依頼内容】\n"
+            "上記脆弱性情報をご確認いただき、バージョンが低い場合は"
+            "バージョンアップのご対応をお願いいたします。\n"
+            "対応を実施した場合はサーバのホスト名をご教示ください。\n\n"
+            "【対応完了目標】\n"
+            "2026/2/17"
+        )
+        self.assertEqual(text, expected)
+
+    def test_structured_alert_text_defaults_when_inputs_missing(self):
+        text = self.chat_tools._build_structured_alert_text(
+            affected_systems=[],
+            vulnerability_id="CVE-2026-9999",
+            title="",
+            cvss_score=None,
+            vulnerability_links=None,
+            deadline="2026/3/1",
+            remediation="手順Aを実施してください。",
+        )
+
+        self.assertIn("【対象の機器/アプリ】\n不明", text)
+        self.assertIn("https://nvd.nist.gov/vuln/detail/CVE-2026-9999", text)
+        self.assertIn("【CVSSスコア】\n不明", text)
+        self.assertIn("【依頼内容】\n手順Aを実施してください。", text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- harden OIDC session cookie handling to avoid auth breakage across http/https and malformed cookies
- fix CORS configuration for credentialed auth requests in OIDC mode
- add regression tests for required chat alert output format and auth/CORS safeguards
- make tool package imports resilient when optional dependencies are missing
- convert 	est_agent.py to opt-in integration test for stable unittest discovery

## Fixes included
- prevent browser cookie rejection by switching SameSite dynamically (
one on HTTPS, lax on HTTP)
- prevent invalid CORS_ALLOW_ORIGINS=* from breaking credentialed auth when OIDC is enabled
- treat malformed signed cookies as unauthenticated instead of raising server errors
- lock notification text output to required structure with explicit tests

## Validation
- python -m unittest discover -v (74 tests, 1 skipped) passed
- python -m compileall -q . passed
- 
ode --check web/app.js passed