### PR TITLE
fix: auto-resolve master agent and render A2A trace as dialogue

### DIFF
--- a/agent/tools/a2a_tools.py
+++ b/agent/tools/a2a_tools.py
@@ -27,6 +27,34 @@ logger = logging.getLogger(__name__)
 _agent_registry: dict[str, Any] = {}
 
 
+def _get_config_value_fallback(
+    env_names: list[str],
+    *,
+    secret_name: str | None = None,
+    default: str = "",
+) -> str:
+    """Resolve config by env first, then optional Secret Manager fallback."""
+    try:
+        from .secret_config import get_config_value  # type: ignore
+    except Exception:
+        try:
+            from agent.tools.secret_config import get_config_value  # type: ignore
+        except Exception:
+            get_config_value = None
+
+    if get_config_value:
+        try:
+            return str(get_config_value(env_names, secret_name=secret_name, default=default) or "").strip()
+        except Exception:
+            pass
+
+    for env_name in env_names:
+        value = str(os.environ.get(env_name) or "").strip()
+        if value:
+            return value
+    return str(default or "").strip()
+
+
 def _is_valid_resource_name(resource_name: str) -> bool:
     text = str(resource_name or "").strip()
     if not text:
@@ -292,13 +320,35 @@ def register_master_agent(
     """
     マスターエージェントを `master_agent` として登録する。
 
-    resource_name 未指定時は REMOTE_AGENT_MASTER 環境変数を使用する。
+    resource_name 未指定時は以下の順で自動解決する。
+    1) REMOTE_AGENT_MASTER / Secret(vuln-agent-master-agent-resource-name)
+    2) REMOTE_AGENT_TEST / REMOTE_AGENT_TEST_DIALOG / Secret(vuln-agent-test-dialog-resource-name)
     """
-    resolved_resource = str(resource_name or "").strip() or str(os.environ.get("REMOTE_AGENT_MASTER", "")).strip()
+    resolved_resource = str(resource_name or "").strip()
+    resolution_source = "argument"
+    if not resolved_resource:
+        resolved_resource = _get_config_value_fallback(
+            ["REMOTE_AGENT_MASTER"],
+            secret_name="vuln-agent-master-agent-resource-name",
+            default="",
+        )
+        if resolved_resource:
+            resolution_source = "master_config"
+    if not resolved_resource:
+        resolved_resource = _get_config_value_fallback(
+            ["REMOTE_AGENT_TEST", "REMOTE_AGENT_TEST_DIALOG"],
+            secret_name="vuln-agent-test-dialog-resource-name",
+            default="",
+        )
+        if resolved_resource:
+            resolution_source = "test_dialog_config"
     if not resolved_resource:
         return {
             "status": "error",
-            "message": "resource_name is required. Set argument or REMOTE_AGENT_MASTER.",
+            "message": (
+                "resource_name is required. Set argument, REMOTE_AGENT_MASTER, "
+                "or configure vuln-agent-test-dialog-resource-name."
+            ),
         }
     result = register_remote_agent(
         agent_id="master_agent",
@@ -307,6 +357,7 @@ def register_master_agent(
     )
     if result.get("status") == "registered":
         result["agent_role"] = "master_agent"
+        result["resolved_from"] = resolution_source
     return result
 
 

--- a/test_a2a_tools.py
+++ b/test_a2a_tools.py
@@ -145,8 +145,25 @@ class A2AToolsTests(unittest.TestCase):
             result = self.a2a_tools.register_master_agent()
             self.assertEqual(result["status"], "registered")
             self.assertEqual(result["agent_id"], "master_agent")
+            self.assertEqual(result["resolved_from"], "master_config")
         finally:
             os.environ.pop("REMOTE_AGENT_MASTER", None)
+
+    def test_register_master_agent_uses_test_dialog_config_fallback(self):
+        original = self.a2a_tools._get_config_value_fallback
+        try:
+            def _fake_get_config(env_names, secret_name=None, default=""):
+                if secret_name == "vuln-agent-test-dialog-resource-name":
+                    return "projects/p1/locations/asia-northeast1/reasoningEngines/777"
+                return ""
+
+            self.a2a_tools._get_config_value_fallback = _fake_get_config
+            result = self.a2a_tools.register_master_agent()
+            self.assertEqual(result["status"], "registered")
+            self.assertEqual(result["agent_id"], "master_agent")
+            self.assertEqual(result["resolved_from"], "test_dialog_config")
+        finally:
+            self.a2a_tools._get_config_value_fallback = original
 
     def test_create_master_agent_handoff_request_requires_fields(self):
         result = self.a2a_tools.create_master_agent_handoff_request(

--- a/web/app.js
+++ b/web/app.js
@@ -718,27 +718,24 @@ function appendA2aTrace(payload) {
 
   const phase = String(payload.phase || "");
   const status = String(payload.status || "");
-  const tool = String(payload.tool || "a2a");
   const agentId = String(payload.agent_id || "unknown");
-  const preview =
-    phase === "call"
-      ? String(payload.message_preview || "").trim()
-      : String(payload.response_preview || "").trim();
-  const phaseLabel = phase === "call" ? "CALL" : "RESULT";
-  const phaseIcon = phase === "call" ? "upload" : status === "error" ? "x-circle" : "download";
-  const statusClass =
-    phase !== "result" ? "" : status === "error" ? "result-error" : "result-success";
+  const requestText = String(payload.request_text || payload.message_preview || "").trim();
+  const responseText = String(payload.response_text || payload.response_preview || "").trim();
+  const phaseLabel = phase === "call" ? "送信" : phase === "result" ? "応答" : "A2A";
+  const phaseIcon = phase === "call" ? "corner-down-right" : status === "error" ? "x-circle" : "message-square";
+  const statusClass = status === "error" ? "result-error" : status === "success" ? "result-success" : "";
+  const bodyText = phase === "call" ? requestText : responseText || requestText;
 
   const item = document.createElement("div");
-  item.className = "a2a-trace-item";
+  item.className = `a2a-trace-item ${phase === "call" ? "a2a-outgoing" : "a2a-incoming"} ${statusClass}`;
   item.innerHTML = `
     <div class="a2a-trace-icon ${statusClass}">
       <i data-lucide="${escapeHtml(phaseIcon)}"></i>
     </div>
     <div class="a2a-trace-body">
-      <div class="a2a-trace-label">${escapeHtml(phaseLabel)} · ${escapeHtml(tool)}</div>
+      <div class="a2a-trace-label">${escapeHtml(phaseLabel)}</div>
       <div class="a2a-trace-agent">${escapeHtml(agentId)}</div>
-      ${preview ? `<div class="a2a-trace-preview">${escapeHtml(preview)}</div>` : ""}
+      ${bodyText ? `<div class="a2a-trace-preview">${escapeHtml(bodyText)}</div>` : ""}
     </div>
     <div class="a2a-trace-time">${formatTime()}</div>
   `;

--- a/web/style.css
+++ b/web/style.css
@@ -793,6 +793,21 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
   margin-top: 6px;
 }
 
+.a2a-trace-item.a2a-outgoing {
+  background: rgba(29, 78, 216, 0.14);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.a2a-trace-item.a2a-incoming {
+  background: rgba(15, 118, 110, 0.16);
+  border-color: rgba(45, 212, 191, 0.4);
+}
+
+.a2a-trace-item.result-error {
+  background: rgba(127, 29, 29, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
 .a2a-trace-icon {
   width: 26px;
   height: 26px;
@@ -822,7 +837,8 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
 
 .a2a-trace-label {
   font-size: var(--font-xs);
-  color: var(--text-muted);
+  color: #cbd5e1;
+  font-weight: 600;
 }
 
 .a2a-trace-agent {
@@ -833,8 +849,8 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
 
 .a2a-trace-preview {
   margin-top: 3px;
-  font-size: var(--font-xs);
-  color: #cbd5e1;
+  font-size: var(--font-sm);
+  color: #e2e8f0;
   white-space: pre-wrap;
   word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- make egister_master_agent resilient by resolving resource from configured fallbacks
- keep A2A trace focused on dialogue content instead of log-style labels
- add unit coverage for master-agent fallback resolution

## Changes
- gent/tools/a2a_tools.py
  - add config fallback helper and expand egister_master_agent resolution order
  - include esolved_from in successful registration result
- 	est_a2a_tools.py
  - add fallback test for test-dialog secret path
- web/app.js
  - render A2A trace with request/response dialogue text
- web/style.css
  - style A2A trace cards as outgoing/incoming conversation blocks

## Validation
- python -m unittest -v test_a2a_tools.py passed (11/11)
