### PR TITLE
Add Cloud Run UI auth gate with OIDC login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,23 @@ Live Gateway は OIDC 認証を有効化できます（Entra ID 対応）。
 動作:
 - `/auth/login` で Entra ID へリダイレクト
 - `/auth/callback` でログイン完了し、セッションCookieを発行
+- `/`（UI本体）, `/app.js`, `/style.css` は未認証時 `/login` にリダイレクト
 - `/ws` は認証済みセッションがないと接続拒否
+
+段階導入:
+- `OIDC_ENABLED=false`（デフォルト）なら従来どおり未認証でもUIにアクセス可能
+- `OIDC_ENABLED=true` に切り替えた時点でUIとWebSocket保護が有効化
+
+監査ログ（ユーザー別チャット追跡）:
+- Live Gateway は `chat_audit` ログをCloud Loggingへ出力
+- 主要フィールド: `user_sub`, `user_email`, `request_id`, `event`, `message`, `response_text`
+- 例:
+```bash
+gcloud run services logs read vuln-agent-live-gateway \
+  --region=asia-northeast1 \
+  --limit=200 \
+  --filter='textPayload:"chat_audit"'
+```
 
 ## よく使う運用コマンド
 再デプロイ:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -68,6 +68,7 @@ steps:
                 DEPLOY_WORKSPACE_EVENTS=true
                 ;;
               web/*)
+                DEPLOY_GATEWAY=true
                 DEPLOY_WEB=true
                 ;;
               README.md|CLAUDE.md|docs/*|.gitignore)
@@ -200,21 +201,34 @@ steps:
           printf '%s' "$$latest_engine" | gcloud secrets create vuln-agent-resource-name-pro --data-file=- >/dev/null
         fi
 
+        protected_display_names="test-dialog-agent,SecSys Router Engine Tokyo v2"
         retention_count="${_AGENT_ENGINE_RETENTION}"
-        if ! [[ "$$retention_count" =~ ^[0-9]+$$ ]] || [ "$$retention_count" -lt 1 ]; then
+        if [ -z "$$retention_count" ]; then
           retention_count="1"
         fi
-
-        delete_targets="$(printf '%s' "$$engines_json" | python3 -c 'import json,sys; retention=int(sys.argv[1]); display_name=sys.argv[2]; engines=json.load(sys.stdin).get("reasoningEngines", []); filtered=[e for e in engines if e.get("displayName")==display_name and e.get("name")]; filtered.sort(key=lambda e: e.get("createTime", ""), reverse=True); print("\n".join(e["name"] for e in filtered[retention:]))' "$$retention_count" "${_AGENT_NAME}")"
-        preserved_engine="$(gcloud secrets versions access latest --secret=vuln-agent-resource-name 2>/dev/null || echo '')"
-        if [ -n "$$preserved_engine" ]; then
-          delete_targets="$(printf '%s\n' "$$delete_targets" | awk -v preserve="$$preserved_engine" '$0 != preserve')"
-        fi
+        preserved_engine="$(gcloud secrets versions access latest --secret=vuln-agent-resource-name 2>/dev/null | tr -d '\r\n ' || echo '')"
+        preserved_flash_engine="$(gcloud secrets versions access latest --secret=vuln-agent-resource-name-flash 2>/dev/null | tr -d '\r\n ' || echo '')"
+        preserved_pro_engine="$(gcloud secrets versions access latest --secret=vuln-agent-resource-name-pro 2>/dev/null | tr -d '\r\n ' || echo '')"
+        keep_engine_names="$${latest_engine},$${preserved_engine},$${preserved_flash_engine},$${preserved_pro_engine}"
+        delete_targets="$(printf '%s' "$$engines_json" | python3 -c 'import json,sys; keep={x for x in sys.argv[1].split(",") if x}; protected={x for x in sys.argv[2].split(",") if x}; engines=json.load(sys.stdin).get("reasoningEngines", []); out=[]; [out.append((e.get("name") or "").strip()) for e in engines if (e.get("name") or "").strip() and (e.get("displayName") or "").strip() and (e.get("displayName") or "").strip() not in protected and (e.get("displayName") or "").strip().startswith("vulnerability-management-agent") and (e.get("name") or "").strip() not in keep]; print("\n".join(out))' "$$keep_engine_names" "$$protected_display_names")"
 
         if [ -n "$$delete_targets" ]; then
+          echo "Old Agent Engine cleanup targets:"
+          printf '%s\n' "$$delete_targets"
           while IFS= read -r engine_name; do
             [ -z "$$engine_name" ] && continue
-            curl -sSf -X DELETE -H "Authorization: Bearer $$token" "$$api_base/$$engine_name" >/dev/null || true
+            deleted=false
+            for attempt in 1 2 3 4 5; do
+              http_code="$(curl -s -o /tmp/engine_delete_response.txt -w "%{http_code}" -X DELETE -H "Authorization: Bearer $$token" "$$api_base/$$engine_name?force=true" || true)"
+              if [ "$$http_code" = "200" ] || [ "$$http_code" = "204" ] || [ "$$http_code" = "404" ]; then
+                deleted=true
+                break
+              fi
+              sleep $$((attempt * 2))
+            done
+            if [ "$$deleted" = "false" ]; then
+              echo "WARN: failed to delete $$engine_name after retries"
+            fi
           done <<< "$$delete_targets"
         fi
     waitFor:
@@ -242,6 +256,11 @@ steps:
           echo "警告: vuln-agent-gemini-api-key が存在しないためスキップ"
           exit 0
         fi
+        mkdir -p live_gateway/ui
+        cp web/index.html live_gateway/ui/index.html
+        cp web/app.js live_gateway/ui/app.js
+        cp web/style.css live_gateway/ui/style.css
+        cp web/login.html live_gateway/ui/login.html
         gcloud run deploy vuln-agent-live-gateway \
           --source=live_gateway \
           --region=${_REGION} \

--- a/live_gateway/README.md
+++ b/live_gateway/README.md
@@ -8,6 +8,8 @@ Vertex AI Agent Engine を橋渡しする最小構成のゲートウェイです
 - 受信したテキストを Agent Engine に問い合わせ
 - Gemini Live API を使った音声ストリーミング（入力/出力）
 - 音声入力は書き起こして Agent Engine に渡し、応答を音声化
+- OIDC有効時はUI/WSを認証セッションで保護
+- 認証ユーザー単位のチャット監査ログ（`chat_audit`）を出力
 
 ## 使い方（ローカル確認）
 ```bash
@@ -32,3 +34,17 @@ gcloud run deploy vuln-agent-live-gateway \
   --set-env-vars=GCP_PROJECT_ID=YOUR_PROJECT_ID,GCP_LOCATION=asia-northeast1,AGENT_RESOURCE_NAME=projects/PROJECT/locations/asia-northeast1/reasoningEngines/AGENT_ID,GEMINI_API_KEY=YOUR_API_KEY \
   --allow-unauthenticated
 ```
+
+## UI保護 + OIDC（Entra ID）
+必要環境変数:
+- `OIDC_ENABLED=true`
+- `OIDC_TENANT_ID=<entra-tenant-id>`
+- `OIDC_CLIENT_ID=<app-registration-client-id>`
+- `OIDC_CLIENT_SECRET=<client-secret>`
+- `OIDC_REDIRECT_URI=https://<live-gateway-domain>/auth/callback`
+- `OIDC_SESSION_SECRET=<32bytes以上のランダム文字列>`
+
+補足:
+- 未認証アクセス時、`/` と静的アセットは `/login` へ遷移します。
+- WebSocket `/ws` は未認証だと `4401 Unauthorized` で切断します。
+- `OIDC_ENABLED=false` では従来動作（UI保護なし）です。

--- a/live_gateway/app.py
+++ b/live_gateway/app.py
@@ -13,11 +13,12 @@ import time
 import urllib.parse
 import urllib.request
 import uuid
+from pathlib import Path
 from typing import Any
 
 import jwt
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import RedirectResponse
+from fastapi.responses import FileResponse, PlainTextResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 import vertexai
 from vertexai import Client
@@ -51,6 +52,7 @@ OIDC_STATE_COOKIE_NAME = os.environ.get("OIDC_STATE_COOKIE_NAME", "vuln_agent_oi
 OIDC_SESSION_TTL_SEC = 8 * 60 * 60
 OIDC_STATE_TTL_SEC = 10 * 60
 CORS_ALLOW_ORIGINS_RAW = os.environ.get("CORS_ALLOW_ORIGINS", "").strip()
+UI_STATIC_DIR = os.environ.get("UI_STATIC_DIR", "").strip()
 _oidc_metadata_cache: dict[str, Any] | None = None
 _oidc_metadata_cache_at = 0.0
 
@@ -360,6 +362,63 @@ def _safe_healthz_headers(request: Request) -> dict[str, str]:
         for key, value in request.headers.items()
         if key.lower() in HEALTHZ_HEADER_ALLOWLIST
     }
+
+
+def _resolve_ui_file(filename: str) -> Path | None:
+    normalized = (filename or "").strip().lstrip("/")
+    if not normalized:
+        return None
+    if ".." in normalized:
+        return None
+
+    candidates: list[Path] = []
+    if UI_STATIC_DIR:
+        candidates.append(Path(UI_STATIC_DIR) / normalized)
+
+    app_dir = Path(__file__).resolve().parent
+    candidates.append(app_dir / "ui" / normalized)
+    candidates.append(app_dir.parent / "web" / normalized)
+
+    for path in candidates:
+        try:
+            if path.is_file():
+                return path
+        except Exception:
+            continue
+    return None
+
+
+def _render_login_fallback() -> str:
+    return (
+        "<!doctype html><html lang='ja'><head><meta charset='utf-8'/>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1'/>"
+        "<title>Login</title></head><body>"
+        "<h1>ログインが必要です</h1>"
+        "<p>このページを利用するには認証してください。</p>"
+        "<a href='/auth/login?next=/'>OIDCログイン</a>"
+        "</body></html>"
+    )
+
+
+def _audit_chat_event(
+    *,
+    event: str,
+    user: dict[str, Any] | None,
+    request_id: str,
+    message: str = "",
+    response_text: str = "",
+) -> None:
+    user = user or {}
+    payload = {
+        "event": event,
+        "user_sub": str(user.get("sub", "")),
+        "user_email": str(user.get("email", "")),
+        "user_name": str(user.get("name", "")),
+        "request_id": str(request_id or ""),
+        "message": str(message or "")[:4000],
+        "response_text": str(response_text or "")[:4000],
+    }
+    logger.info("chat_audit %s", json.dumps(payload, ensure_ascii=False))
 
 
 def _base64url_encode(raw: bytes) -> str:
@@ -904,6 +963,48 @@ def ping():
     return {"status": "ok"}
 
 
+@app.get("/")
+def ui_root(request: Request):
+    if OIDC_ENABLED and not _get_session_user_from_cookie(request.cookies):
+        return RedirectResponse(url="/login", status_code=302)
+    ui_file = _resolve_ui_file("index.html")
+    if not ui_file:
+        return PlainTextResponse("UI index not found", status_code=500)
+    return FileResponse(ui_file)
+
+
+@app.get("/login")
+def ui_login(request: Request):
+    if not OIDC_ENABLED:
+        return RedirectResponse(url="/", status_code=302)
+    if _get_session_user_from_cookie(request.cookies):
+        return RedirectResponse(url="/", status_code=302)
+    ui_file = _resolve_ui_file("login.html")
+    if ui_file:
+        return FileResponse(ui_file)
+    return PlainTextResponse(_render_login_fallback(), media_type="text/html; charset=utf-8")
+
+
+@app.get("/app.js")
+def ui_app_js(request: Request):
+    if OIDC_ENABLED and not _get_session_user_from_cookie(request.cookies):
+        return RedirectResponse(url="/login", status_code=302)
+    ui_file = _resolve_ui_file("app.js")
+    if not ui_file:
+        return PlainTextResponse("app.js not found", status_code=404)
+    return FileResponse(ui_file, media_type="application/javascript; charset=utf-8")
+
+
+@app.get("/style.css")
+def ui_style_css(request: Request):
+    if OIDC_ENABLED and not _get_session_user_from_cookie(request.cookies):
+        return RedirectResponse(url="/login", status_code=302)
+    ui_file = _resolve_ui_file("style.css")
+    if not ui_file:
+        return PlainTextResponse("style.css not found", status_code=404)
+    return FileResponse(ui_file, media_type="text/css; charset=utf-8")
+
+
 @app.get("/auth/me")
 def auth_me(request: Request):
     if not OIDC_ENABLED:
@@ -1123,8 +1224,20 @@ async def websocket_endpoint(websocket: WebSocket):
                 return
             last_response_index = len(transcript_parts)
             agent_response = await _query_agent(client, transcript, websocket, ws_user_id)
+            _audit_chat_event(
+                event="voice_request",
+                user=ws_user,
+                request_id=str(agent_response.get("request_id", "")),
+                message=transcript,
+            )
             await _safe_send(websocket, agent_response)
             response_text = agent_response.get("text", "")
+            _audit_chat_event(
+                event="voice_response",
+                user=ws_user,
+                request_id=str(agent_response.get("request_id", "")),
+                response_text=response_text,
+            )
             if response_text:
                 await _safe_send(websocket, {"type": "live_text", "text": response_text})
             if response_text:
@@ -1186,6 +1299,18 @@ async def websocket_endpoint(websocket: WebSocket):
                     continue
 
                 response = await _query_agent(client, message, websocket, ws_user_id)
+                _audit_chat_event(
+                    event="text_request",
+                    user=ws_user,
+                    request_id=str(response.get("request_id", "")),
+                    message=message,
+                )
+                _audit_chat_event(
+                    event="text_response",
+                    user=ws_user,
+                    request_id=str(response.get("request_id", "")),
+                    response_text=str(response.get("text", "")),
+                )
                 await websocket.send_text(json.dumps(response, ensure_ascii=False))
                 continue
 

--- a/live_gateway/test_health_endpoints.py
+++ b/live_gateway/test_health_endpoints.py
@@ -100,6 +100,22 @@ class HealthEndpointTests(unittest.TestCase):
         self.assertIn('"message": "追加情報待ち"', source)
         self.assertIn('AMBIGUITY_PRESET_NAME = (os.environ.get("AMBIGUITY_PRESET") or "standard")', source)
 
+    def test_ui_auth_gate_routes_exist(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn('@app.get("/login")', source)
+        self.assertIn('@app.get("/app.js")', source)
+        self.assertIn('@app.get("/style.css")', source)
+        self.assertIn("RedirectResponse(url=\"/login\", status_code=302)", source)
+        self.assertIn("def _resolve_ui_file", source)
+
+    def test_chat_audit_logging_exists(self):
+        source = APP_FILE.read_text(encoding="utf-8")
+        self.assertIn("def _audit_chat_event", source)
+        self.assertIn('event="text_request"', source)
+        self.assertIn('event="text_response"', source)
+        self.assertIn('event="voice_request"', source)
+        self.assertIn('event="voice_response"', source)
+
     def test_model_routing_for_flash_pro_exists(self):
         source = APP_FILE.read_text(encoding="utf-8")
         self.assertIn("AGENT_RESOURCE_NAME_FLASH", source)

--- a/web/login.html
+++ b/web/login.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vulnerability Agent Login</title>
+    <style>
+      :root {
+        --bg: #0b1020;
+        --panel: #121b33;
+        --border: #24324f;
+        --text: #e2e8f0;
+        --muted: #94a3b8;
+        --primary: #3b82f6;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 20% 20%, #1b2a4a 0%, var(--bg) 55%);
+        color: var(--text);
+        font-family: "Inter", "Segoe UI", sans-serif;
+      }
+      .card {
+        width: min(460px, calc(100vw - 32px));
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 24px;
+      }
+      h1 {
+        margin: 0 0 8px 0;
+        font-size: 1.2rem;
+      }
+      p {
+        margin: 0 0 18px 0;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+      .actions { display: flex; gap: 10px; }
+      a {
+        display: inline-block;
+        text-decoration: none;
+        padding: 10px 14px;
+        border-radius: 10px;
+        font-size: 0.95rem;
+      }
+      .primary {
+        background: var(--primary);
+        color: #fff;
+      }
+      .ghost {
+        color: var(--muted);
+        border: 1px solid var(--border);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>ログインが必要です</h1>
+      <p>
+        このアプリは OIDC 認証後に利用できます。<br />
+        Entra ID でサインインして続行してください。
+      </p>
+      <div class="actions">
+        <a class="primary" href="/auth/login?next=/">OIDC ログイン</a>
+        <a class="ghost" href="/auth/me">認証状態を確認</a>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- protect Cloud Run-served UI routes (/, /app.js, /style.css) behind OIDC session when enabled
- add /login page and static login fallback for unauthenticated users
- add chat audit logging (chat_audit) with authenticated user identity fields
- include login/static UI assets in live-gateway Cloud Build deployment
- document Entra OIDC setup and user-level audit log verification

## Test
- python -m unittest -v live_gateway/test_health_endpoints.py
- python -m unittest -v test_a2a_tools.py