### PR TITLE
UI: simplify history panel controls and maximize horizontal layout

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -9,6 +9,7 @@ const connectButton = document.getElementById("connect-button");
 const disconnectButton = document.getElementById("disconnect-button");
 const loginButton = document.getElementById("login-button");
 const logoutButton = document.getElementById("logout-button");
+const toggleHistoryButton = document.getElementById("toggle-history");
 const gatewayInput = document.getElementById("gateway-url");
 const chatForm = document.getElementById("chat-form");
 const chatInput = document.getElementById("chat-input");
@@ -28,8 +29,6 @@ const a2aTraceFeed = document.getElementById("a2a-trace-feed");
 const clearA2aTraceButton = document.getElementById("clear-a2a-trace");
 const historyFeed = document.getElementById("history-feed");
 const historyUser = document.getElementById("history-user");
-const clearHistoryButton = document.getElementById("clear-history");
-const newThreadButton = document.getElementById("new-thread");
 const pingLatencyText = document.getElementById("ping-latency");
 const reconnectCountText = document.getElementById("reconnect-count");
 const toastContainer = document.getElementById("toast-container");
@@ -1276,13 +1275,6 @@ clearActivityButton?.addEventListener("click", () => {
 clearA2aTraceButton?.addEventListener("click", () => {
   resetA2aTraceFeed();
 });
-clearHistoryButton?.addEventListener("click", () => {
-  clearHistoryForCurrentUser();
-});
-newThreadButton?.addEventListener("click", () => {
-  createAndSelectNewThread();
-  appendMessage("新しいスレッドを開始しました。", "system");
-});
 historyFeed?.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
@@ -1292,6 +1284,9 @@ historyFeed?.addEventListener("click", (event) => {
   if (!threadId) return;
   selectThread(threadId);
   appendMessage("過去スレッドを読み込みました。このまま会話を再開できます。", "system");
+});
+toggleHistoryButton?.addEventListener("click", () => {
+  document.body.classList.toggle("history-collapsed");
 });
 
 voiceSessionCloseButton.addEventListener("click", async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -65,6 +65,10 @@
             <i data-lucide="log-out"></i>
             <span>Logout</span>
           </button>
+          <button id="toggle-history" class="btn btn-outline" type="button">
+            <i data-lucide="panel-left"></i>
+            <span>History</span>
+          </button>
         </div>
       </section>
 
@@ -76,12 +80,6 @@
             <i data-lucide="history"></i>
             <span>Chat Threads</span>
             <span class="history-user" id="history-user">User: anonymous</span>
-            <button class="btn-icon" id="new-thread" title="New Thread">
-              <i data-lucide="plus"></i>
-            </button>
-            <button class="btn-icon" id="clear-history" title="Clear History">
-              <i data-lucide="x"></i>
-            </button>
           </div>
           <div id="history-feed" class="history-feed">
             <div class="activity-empty">
@@ -136,8 +134,8 @@
           <div class="panel-header">
             <i data-lucide="network"></i>
             <span>A2A Trace</span>
-            <button class="btn-icon" id="clear-a2a-trace" title="Clear A2A Trace">
-              <i data-lucide="x"></i>
+            <button class="btn btn-outline btn-clear" id="clear-a2a-trace" title="Clear A2A Trace">
+              <span>Clear</span>
             </button>
           </div>
           <div id="a2a-trace-feed" class="a2a-trace-feed">

--- a/web/style.css
+++ b/web/style.css
@@ -295,13 +295,17 @@ body {
 .main-content {
   flex: 1;
   display: grid;
-  grid-template-columns: 320px minmax(0, 1fr) 360px;
+  grid-template-columns: 300px minmax(0, 1fr) 360px;
   gap: 16px;
-  max-width: 1780px;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   width: 100%;
-  padding: 16px 24px 24px;
+  padding: 16px;
   min-height: 0;
+}
+
+body.history-collapsed .main-content {
+  grid-template-columns: 44px minmax(0, 1fr) 360px;
 }
 
 /* ── Panel Header ────────────────────────────── */
@@ -324,6 +328,12 @@ body {
 
 .panel-header .btn-icon {
   margin-left: auto;
+}
+
+.btn-clear {
+  margin-left: auto;
+  padding: 4px 10px;
+  font-size: var(--font-xs);
 }
 
 .activity-meta {
@@ -818,6 +828,25 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
   text-overflow: ellipsis;
 }
 
+body.history-collapsed .history-panel {
+  padding: 8px 6px;
+}
+
+body.history-collapsed .history-panel .panel-header {
+  justify-content: center;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+body.history-collapsed .history-panel .panel-header span {
+  display: none;
+}
+
+body.history-collapsed .history-feed {
+  display: none;
+}
+
 .thread-item-preview {
   font-size: var(--font-xs);
   color: #cbd5e1;
@@ -1226,6 +1255,10 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
 
   .history-feed {
     max-height: 34vh;
+  }
+
+  body.history-collapsed .main-content {
+    grid-template-columns: 1fr;
   }
 
   .a2a-trace-feed {


### PR DESCRIPTION
## Summary
- replace top-right close icon in A2A panel with Clear text button
- remove buttons from left chat history header (no controls in history panel)
- expand layout to use full horizontal width
- add left history collapse/expand toggle from top control bar
- keep thread selection and resume behavior from left panel

## Files
- web/index.html
- web/style.css
- web/app.js

## Validation
- node --check web/app.js