### PR TITLE
Add new chat button in left history panel

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -29,6 +29,7 @@ const a2aTraceFeed = document.getElementById("a2a-trace-feed");
 const clearA2aTraceButton = document.getElementById("clear-a2a-trace");
 const historyFeed = document.getElementById("history-feed");
 const historyUser = document.getElementById("history-user");
+const newThreadButton = document.getElementById("new-thread");
 const pingLatencyText = document.getElementById("ping-latency");
 const reconnectCountText = document.getElementById("reconnect-count");
 const toastContainer = document.getElementById("toast-container");
@@ -1274,6 +1275,10 @@ clearActivityButton?.addEventListener("click", () => {
 });
 clearA2aTraceButton?.addEventListener("click", () => {
   resetA2aTraceFeed();
+});
+newThreadButton?.addEventListener("click", () => {
+  createAndSelectNewThread();
+  appendMessage("新しいスレッドを開始しました。", "system");
 });
 historyFeed?.addEventListener("click", (event) => {
   const target = event.target;

--- a/web/index.html
+++ b/web/index.html
@@ -81,6 +81,10 @@
             <span>Chat Threads</span>
             <span class="history-user" id="history-user">User: anonymous</span>
           </div>
+          <button id="new-thread" class="btn btn-outline history-new-thread" type="button">
+            <i data-lucide="plus"></i>
+            <span>新規チャット</span>
+          </button>
           <div id="history-feed" class="history-feed">
             <div class="activity-empty">
               <i data-lucide="history" class="empty-icon"></i>

--- a/web/style.css
+++ b/web/style.css
@@ -763,6 +763,12 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
   padding-right: 4px;
 }
 
+.history-new-thread {
+  width: 100%;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
 .history-feed::-webkit-scrollbar {
   width: 6px;
 }
@@ -844,6 +850,10 @@ body.history-collapsed .history-panel .panel-header span {
 }
 
 body.history-collapsed .history-feed {
+  display: none;
+}
+
+body.history-collapsed .history-new-thread {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- add a new "新規チャット" button in the left chat history panel
- wire the button to create and select a new thread immediately
- add styling so the button matches existing UI and hides when history is collapsed

## Testing
- node --check web/app.js
- manual UI verification for new-thread button behavior
