### PR TITLE
Add thread deletion and top feature toolbar

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -30,6 +30,7 @@ const clearA2aTraceButton = document.getElementById("clear-a2a-trace");
 const historyFeed = document.getElementById("history-feed");
 const historyUser = document.getElementById("history-user");
 const newThreadButton = document.getElementById("new-thread");
+const featureToolbar = document.getElementById("feature-toolbar");
 const pingLatencyText = document.getElementById("ping-latency");
 const reconnectCountText = document.getElementById("reconnect-count");
 const toastContainer = document.getElementById("toast-container");
@@ -542,8 +543,13 @@ function renderHistoryFeed() {
     item.dataset.threadId = thread.id;
     item.innerHTML = `
       <div class="thread-item-header">
-        <i data-lucide="messages-square"></i>
-        <span>${escapeHtml(updatedAt)}</span>
+        <div class="thread-item-time">
+          <i data-lucide="messages-square"></i>
+          <span>${escapeHtml(updatedAt)}</span>
+        </div>
+        <button class="thread-delete-btn" type="button" title="Delete thread" aria-label="Delete thread">
+          <i data-lucide="trash-2"></i>
+        </button>
       </div>
       <div class="thread-item-title">${escapeHtml(String(thread.title || "新しいスレッド"))}</div>
       <div class="thread-item-preview">${escapeHtml(lastMessage || "メッセージなし")}</div>
@@ -594,6 +600,19 @@ function createAndSelectNewThread(initialText = "") {
     threadList = threadList.slice(0, MAX_THREADS);
   }
   activeThreadId = next.id;
+  saveThreadsForCurrentUser();
+  renderHistoryFeed();
+  hydrateChatFromActiveThread();
+}
+
+function deleteThread(threadId) {
+  if (!threadId) return;
+  if (!threadList.some((thread) => thread.id === threadId)) return;
+  threadList = threadList.filter((thread) => thread.id !== threadId);
+  if (activeThreadId === threadId) {
+    activeThreadId = threadList[0]?.id || "";
+  }
+  ensureActiveThread(true);
   saveThreadsForCurrentUser();
   renderHistoryFeed();
   hydrateChatFromActiveThread();
@@ -1283,12 +1302,32 @@ newThreadButton?.addEventListener("click", () => {
 historyFeed?.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
+  const deleteButton = target.closest(".thread-delete-btn");
+  if (deleteButton) {
+    const ownerItem = deleteButton.closest(".thread-item");
+    const ownerThreadId = ownerItem?.getAttribute("data-thread-id");
+    if (!ownerThreadId) return;
+    deleteThread(ownerThreadId);
+    appendMessage("スレッドを削除しました。", "system");
+    return;
+  }
   const item = target.closest(".thread-item");
   if (!item) return;
   const threadId = item.getAttribute("data-thread-id");
   if (!threadId) return;
   selectThread(threadId);
   appendMessage("過去スレッドを読み込みました。このまま会話を再開できます。", "system");
+});
+featureToolbar?.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  const button = target.closest(".feature-action-btn");
+  if (!button) return;
+  const prompt = button.getAttribute("data-prompt");
+  if (!prompt) return;
+  chatInput.value = prompt;
+  resizeChatInput();
+  chatInput.focus();
 });
 toggleHistoryButton?.addEventListener("click", () => {
   document.body.classList.toggle("history-collapsed");

--- a/web/index.html
+++ b/web/index.html
@@ -99,6 +99,13 @@
             <i data-lucide="message-square"></i>
             <span>Chat</span>
           </div>
+          <div class="feature-toolbar" id="feature-toolbar">
+            <button class="feature-action-btn" type="button" data-prompt="SBOMの内容を一覧で教えてください。">SBOM一覧</button>
+            <button class="feature-action-btn" type="button" data-prompt="SBOMをtypeごとに集計して教えてください。">SBOM集計</button>
+            <button class="feature-action-btn" type="button" data-prompt="SIDfmの未読脆弱性メールを確認してください。">未読メール確認</button>
+            <button class="feature-action-btn" type="button" data-prompt="A2Aの接続状態を確認してください。">A2A接続確認</button>
+            <button class="feature-action-btn" type="button" data-prompt="脆弱性通知文を作成してください。">通知文作成</button>
+          </div>
           <div id="messages" class="messages-area"></div>
 
           <!-- Audio controls -->

--- a/web/style.css
+++ b/web/style.css
@@ -367,6 +367,42 @@ body.history-collapsed .main-content {
   padding-right: 4px;
 }
 
+.feature-toolbar {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 0 0 10px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.feature-toolbar::-webkit-scrollbar {
+  height: 6px;
+}
+
+.feature-toolbar::-webkit-scrollbar-thumb {
+  background: var(--border-secondary);
+  border-radius: var(--radius-full);
+}
+
+.feature-action-btn {
+  border: 1px solid var(--border-secondary);
+  background: #12203a;
+  color: #dbeafe;
+  border-radius: var(--radius-full);
+  padding: 6px 12px;
+  font-size: var(--font-xs);
+  font-family: var(--font-family);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.feature-action-btn:hover {
+  background: #16325f;
+  border-color: #4f8cff;
+}
+
 .messages-area::-webkit-scrollbar {
   width: 6px;
 }
@@ -819,10 +855,41 @@ body.mode-listening .voice-orb.voice-orb-listening .voice-orb-ring {
 .thread-item-header {
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: space-between;
   font-size: var(--font-xs);
   color: var(--text-secondary);
   margin-bottom: 4px;
+}
+
+.thread-item-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.thread-delete-btn {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.thread-delete-btn i {
+  width: 13px;
+  height: 13px;
+}
+
+.thread-delete-btn:hover {
+  color: #fecaca;
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 .thread-item-title {
@@ -1261,6 +1328,10 @@ body.history-collapsed .history-new-thread {
   .messages-area {
     max-height: none;
     min-height: 200px;
+  }
+
+  .feature-toolbar {
+    margin-bottom: 8px;
   }
 
   .history-feed {


### PR DESCRIPTION
## Summary
- add delete button per chat thread in left history panel
- support deleting active/non-active thread with safe fallback to next/new thread
- add top feature toolbar buttons inside chat area to quickly fill prompt templates

## Testing
- node --check web/app.js
- manual click test for thread delete and feature buttons
